### PR TITLE
PAB: get rid of ON/OFF toggle for crafting bag items (saved vars update)

### DIFF
--- a/PersonalAssistant/PersonalAssistantBanking/Menu/PABankingMenu.lua
+++ b/PersonalAssistant/PersonalAssistantBanking/Menu/PABankingMenu.lua
@@ -626,15 +626,6 @@ end
 -- =================================================================================================================
 
 local function _createPABCraftingBlacksmithingSubmenuTable()
-    PABCraftingBlacksmithingSubmenuTable:insert({
-        type = "checkbox",
-        name = GetString(SI_PA_MENU_BANKING_CRAFTING_BLACKSMITHING_ITEMS_ENABLE),
-        getFunc = PABMenuFunctions.getBlacksmithingTransactionSetting,
-        setFunc = PABMenuFunctions.setBlacksmithingTransactionSetting,
-        disabled = PABMenuFunctions.isBlacksmithingTransactionDisabled,
-        default = PABMenuDefaults.Crafting.TransactionSettings.blacksmithingEnabled,
-    })
-
     for _, itemType in pairs(PAC.BANKING.BLACKSMITHING) do
         PABCraftingBlacksmithingSubmenuTable:insert({
             type = "dropdown",
@@ -643,8 +634,8 @@ local function _createPABCraftingBlacksmithingSubmenuTable()
             choicesValues = PABMenuChoicesValues.itemMoveMode,
             getFunc = function() return PABMenuFunctions.getCraftingItemTypeMoveSetting(itemType) end,
             setFunc = function(value) PABMenuFunctions.setCraftingItemTypeMoveSetting(itemType, value) end,
-            disabled = PABMenuFunctions.isBlacksmithingTransactionMenuDisabled,
-            default = PABMenuDefaults.Crafting.ItemTypes[itemType].moveMode,
+            disabled = function() return not PABMenuFunctions.getCraftingItemsEnabledSetting() end,
+            default = PABMenuDefaults.Crafting.ItemTypes[itemType],
         })
     end
 end
@@ -652,15 +643,6 @@ end
 -- -----------------------------------------------------------------------------------------------------------------
 
 local function _createPABCraftingClothingSubmenuTable()
-    PABCraftingClothingSubmenuTable:insert({
-        type = "checkbox",
-        name = GetString(SI_PA_MENU_BANKING_CRAFTING_CLOTHING_ITEMS_ENABLE),
-        getFunc = PABMenuFunctions.getClothingTransactionSetting,
-        setFunc = PABMenuFunctions.setClothingTransactionSetting,
-        disabled = PABMenuFunctions.isClothingTransactionDisabled,
-        default = PABMenuDefaults.Crafting.TransactionSettings.clothingEnabled,
-    })
-
     for _, itemType in pairs(PAC.BANKING.CLOTHING) do
         PABCraftingClothingSubmenuTable:insert({
             type = "dropdown",
@@ -669,8 +651,8 @@ local function _createPABCraftingClothingSubmenuTable()
             choicesValues = PABMenuChoicesValues.itemMoveMode,
             getFunc = function() return PABMenuFunctions.getCraftingItemTypeMoveSetting(itemType) end,
             setFunc = function(value) PABMenuFunctions.setCraftingItemTypeMoveSetting(itemType, value) end,
-            disabled = PABMenuFunctions.isClothingTransactionMenuDisabled,
-            default = PABMenuDefaults.Crafting.ItemTypes[itemType].moveMode,
+            disabled = function() return not PABMenuFunctions.getCraftingItemsEnabledSetting() end,
+            default = PABMenuDefaults.Crafting.ItemTypes[itemType],
         })
     end
 end
@@ -678,15 +660,6 @@ end
 -- -----------------------------------------------------------------------------------------------------------------
 
 local function _createPABCraftingWoodworkingSubmenuTable()
-    PABCraftingWoodworkingSubmenuTable:insert({
-        type = "checkbox",
-        name = GetString(SI_PA_MENU_BANKING_CRAFTING_WOODWORKING_ITEMS_ENABLE),
-        getFunc = PABMenuFunctions.getWoodworkingTransactionSetting,
-        setFunc = PABMenuFunctions.setWoodworkingTransactionSetting,
-        disabled = PABMenuFunctions.isWoodworkingTransactionDisabled,
-        default = PABMenuDefaults.Crafting.TransactionSettings.woodworkingEnabled,
-    })
-
     for _, itemType in pairs(PAC.BANKING.WOODWORKING) do
         PABCraftingWoodworkingSubmenuTable:insert({
             type = "dropdown",
@@ -695,8 +668,8 @@ local function _createPABCraftingWoodworkingSubmenuTable()
             choicesValues = PABMenuChoicesValues.itemMoveMode,
             getFunc = function() return PABMenuFunctions.getCraftingItemTypeMoveSetting(itemType) end,
             setFunc = function(value) PABMenuFunctions.setCraftingItemTypeMoveSetting(itemType, value) end,
-            disabled = PABMenuFunctions.isWoodworkingTransactionMenuDisabled,
-            default = PABMenuDefaults.Crafting.ItemTypes[itemType].moveMode,
+            disabled = function() return not PABMenuFunctions.getCraftingItemsEnabledSetting() end,
+            default = PABMenuDefaults.Crafting.ItemTypes[itemType],
         })
     end
 end
@@ -704,15 +677,6 @@ end
 -- -----------------------------------------------------------------------------------------------------------------
 
 local function _createPABCraftingJewelcraftingSubmenuTable()
-    PABCraftingJewelcraftingSubmenuTable:insert({
-        type = "checkbox",
-        name = GetString(SI_PA_MENU_BANKING_CRAFTING_JEWELCRAFTING_ITEMS_ENABLE),
-        getFunc = PABMenuFunctions.getJewelcraftingTransactionSetting,
-        setFunc = PABMenuFunctions.setJewelcraftingTransactionSetting,
-        disabled = PABMenuFunctions.isJewelcraftingTransactionDisabled,
-        default = PABMenuDefaults.Crafting.TransactionSettings.jewelcraftingEnabled,
-    })
-
     for _, itemType in pairs(PAC.BANKING.JEWELCRAFTING) do
         PABCraftingJewelcraftingSubmenuTable:insert({
             type = "dropdown",
@@ -721,8 +685,8 @@ local function _createPABCraftingJewelcraftingSubmenuTable()
             choicesValues = PABMenuChoicesValues.itemMoveMode,
             getFunc = function() return PABMenuFunctions.getCraftingItemTypeMoveSetting(itemType) end,
             setFunc = function(value) PABMenuFunctions.setCraftingItemTypeMoveSetting(itemType, value) end,
-            disabled = PABMenuFunctions.isJewelcraftingTransactionMenuDisabled,
-            default = PABMenuDefaults.Crafting.ItemTypes[itemType].moveMode,
+            disabled = function() return not PABMenuFunctions.getCraftingItemsEnabledSetting() end,
+            default = PABMenuDefaults.Crafting.ItemTypes[itemType],
         })
     end
 end
@@ -730,15 +694,6 @@ end
 -- -----------------------------------------------------------------------------------------------------------------
 
 local function _createPABCraftingAlchemySubmenuTable()
-    PABCraftingAlchemySubmenuTable:insert({
-        type = "checkbox",
-        name = GetString(SI_PA_MENU_BANKING_CRAFTING_ALCHEMY_ITEMS_ENABLE),
-        getFunc = PABMenuFunctions.getAlchemyTransactionSetting,
-        setFunc = PABMenuFunctions.setAlchemyTransactionSetting,
-        disabled = PABMenuFunctions.isAlchemyTransactionDisabled,
-        default = PABMenuDefaults.Crafting.TransactionSettings.alchemyEnabled,
-    })
-
     for _, itemType in pairs(PAC.BANKING.ALCHEMY) do
         PABCraftingAlchemySubmenuTable:insert({
             type = "dropdown",
@@ -747,8 +702,8 @@ local function _createPABCraftingAlchemySubmenuTable()
             choicesValues = PABMenuChoicesValues.itemMoveMode,
             getFunc = function() return PABMenuFunctions.getCraftingItemTypeMoveSetting(itemType) end,
             setFunc = function(value) PABMenuFunctions.setCraftingItemTypeMoveSetting(itemType, value) end,
-            disabled = PABMenuFunctions.isAlchemyTransactionMenuDisabled,
-            default = PABMenuDefaults.Crafting.ItemTypes[itemType].moveMode,
+            disabled = function() return not PABMenuFunctions.getCraftingItemsEnabledSetting() end,
+            default = PABMenuDefaults.Crafting.ItemTypes[itemType],
         })
     end
 end
@@ -756,15 +711,6 @@ end
 -- -----------------------------------------------------------------------------------------------------------------
 
 local function _createPABCraftingEnchantingSubmenuTable()
-    PABCraftingEnchantingSubmenuTable:insert({
-        type = "checkbox",
-        name = GetString(SI_PA_MENU_BANKING_CRAFTING_ENCHANTING_ITEMS_ENABLE),
-        getFunc = PABMenuFunctions.getEnchantingTransactionSetting,
-        setFunc = PABMenuFunctions.setEnchantingTransactionSetting,
-        disabled = PABMenuFunctions.isEnchantingTransactionDisabled,
-        default = PABMenuDefaults.Crafting.TransactionSettings.enchantingEnabled,
-    })
-
     for _, itemType in pairs(PAC.BANKING.ENCHANTING) do
         PABCraftingEnchantingSubmenuTable:insert({
             type = "dropdown",
@@ -773,8 +719,8 @@ local function _createPABCraftingEnchantingSubmenuTable()
             choicesValues = PABMenuChoicesValues.itemMoveMode,
             getFunc = function() return PABMenuFunctions.getCraftingItemTypeMoveSetting(itemType) end,
             setFunc = function(value) PABMenuFunctions.setCraftingItemTypeMoveSetting(itemType, value) end,
-            disabled = PABMenuFunctions.isEnchantingTransactionMenuDisabled,
-            default = PABMenuDefaults.Crafting.ItemTypes[itemType].moveMode,
+            disabled = function() return not PABMenuFunctions.getCraftingItemsEnabledSetting() end,
+            default = PABMenuDefaults.Crafting.ItemTypes[itemType],
         })
     end
 end
@@ -782,15 +728,6 @@ end
 -- -----------------------------------------------------------------------------------------------------------------
 
 local function _createPABCraftingProvisioningSubmenuTable()
-    PABCraftingProvisioningSubmenuTable:insert({
-        type = "checkbox",
-        name = GetString(SI_PA_MENU_BANKING_CRAFTING_PROVISIONING_ITEMS_ENABLE),
-        getFunc = PABMenuFunctions.getProvisioningTransactionSetting,
-        setFunc = PABMenuFunctions.setProvisioningTransactionSetting,
-        disabled = PABMenuFunctions.isProvisioningTransactionDisabled,
-        default = PABMenuDefaults.Crafting.TransactionSettings.provisioningEnabled,
-    })
-
     for _, itemType in pairs(PAC.BANKING.PROVISIONING) do
         PABCraftingProvisioningSubmenuTable:insert({
             type = "dropdown",
@@ -799,8 +736,8 @@ local function _createPABCraftingProvisioningSubmenuTable()
             choicesValues = PABMenuChoicesValues.itemMoveMode,
             getFunc = function() return PABMenuFunctions.getCraftingItemTypeMoveSetting(itemType) end,
             setFunc = function(value) PABMenuFunctions.setCraftingItemTypeMoveSetting(itemType, value) end,
-            disabled = PABMenuFunctions.isProvisioningTransactionMenuDisabled,
-            default = PABMenuDefaults.Crafting.ItemTypes[itemType].moveMode,
+            disabled = function() return not PABMenuFunctions.getCraftingItemsEnabledSetting() end,
+            default = PABMenuDefaults.Crafting.ItemTypes[itemType],
         })
     end
 end
@@ -808,15 +745,6 @@ end
 -- -----------------------------------------------------------------------------------------------------------------
 
 local function _createPABCraftingStyleMaterialsSubmenuTable()
-    PABCraftingStyleMaterialsSubmenuTable:insert({
-        type = "checkbox",
-        name = GetString(SI_PA_MENU_BANKING_CRAFTING_STYLEMATERIALS_ITEMS_ENABLE),
-        getFunc = PABMenuFunctions.getStyleMaterialsTransactionSetting,
-        setFunc = PABMenuFunctions.setStyleMaterialsTransactionSetting,
-        disabled = PABMenuFunctions.isStyleMaterialsTransactionDisabled,
-        default = PABMenuDefaults.Crafting.TransactionSettings.styleMaterialsEnabled,
-    })
-
     for _, itemType in pairs(PAC.BANKING.STYLEMATERIALS) do
         PABCraftingStyleMaterialsSubmenuTable:insert({
             type = "dropdown",
@@ -825,8 +753,8 @@ local function _createPABCraftingStyleMaterialsSubmenuTable()
             choicesValues = PABMenuChoicesValues.itemMoveMode,
             getFunc = function() return PABMenuFunctions.getCraftingItemTypeMoveSetting(itemType) end,
             setFunc = function(value) PABMenuFunctions.setCraftingItemTypeMoveSetting(itemType, value) end,
-            disabled = PABMenuFunctions.isStyleMaterialsTransactionMenuDisabled,
-            default = PABMenuDefaults.Crafting.ItemTypes[itemType].moveMode,
+            disabled = function() return not PABMenuFunctions.getCraftingItemsEnabledSetting() end,
+            default = PABMenuDefaults.Crafting.ItemTypes[itemType],
         })
     end
 end
@@ -834,15 +762,6 @@ end
 -- -----------------------------------------------------------------------------------------------------------------
 
 local function _createPABCraftingTraitItemsSubmenuTable()
-    PABCraftingTraitItemsSubmenuTable:insert({
-        type = "checkbox",
-        name = GetString(SI_PA_MENU_BANKING_CRAFTING_TRAITITEMS_ITEMS_ENABLE),
-        getFunc = PABMenuFunctions.getTraitItemsTransactionSetting,
-        setFunc = PABMenuFunctions.setTraitItemsTransactionSetting,
-        disabled = PABMenuFunctions.isTraitItemsTransactionDisabled,
-        default = PABMenuDefaults.Crafting.TransactionSettings.traitItemsEnabled,
-    })
-
     for _, itemType in pairs(PAC.BANKING.TRAITITEMS) do
         PABCraftingTraitItemsSubmenuTable:insert({
             type = "dropdown",
@@ -851,8 +770,8 @@ local function _createPABCraftingTraitItemsSubmenuTable()
             choicesValues = PABMenuChoicesValues.itemMoveMode,
             getFunc = function() return PABMenuFunctions.getCraftingItemTypeMoveSetting(itemType) end,
             setFunc = function(value) PABMenuFunctions.setCraftingItemTypeMoveSetting(itemType, value) end,
-            disabled = PABMenuFunctions.isTraitItemsTransactionMenuDisabled,
-            default = PABMenuDefaults.Crafting.ItemTypes[itemType].moveMode,
+            disabled = function() return not PABMenuFunctions.getCraftingItemsEnabledSetting() end,
+            default = PABMenuDefaults.Crafting.ItemTypes[itemType],
         })
     end
 end
@@ -860,15 +779,6 @@ end
 -- -----------------------------------------------------------------------------------------------------------------
 
 local function _createPABCraftingFurnishingSubmenuTable()
-    PABCraftingFurnishingSubmenuTable:insert({
-        type = "checkbox",
-        name = GetString(SI_PA_MENU_BANKING_CRAFTING_FURNISHING_ITEMS_ENABLE),
-        getFunc = PABMenuFunctions.getFurnishingTransactionSetting,
-        setFunc = PABMenuFunctions.setFurnishingTransactionSetting,
-        disabled = PABMenuFunctions.isFurnishingTransactionDisabled,
-        default = PABMenuDefaults.Crafting.TransactionSettings.furnishingEnabled,
-    })
-
     for _, itemType in pairs(PAC.BANKING.FURNISHING) do
         PABCraftingFurnishingSubmenuTable:insert({
             type = "dropdown",
@@ -877,8 +787,8 @@ local function _createPABCraftingFurnishingSubmenuTable()
             choicesValues = PABMenuChoicesValues.itemMoveMode,
             getFunc = function() return PABMenuFunctions.getCraftingItemTypeMoveSetting(itemType) end,
             setFunc = function(value) PABMenuFunctions.setCraftingItemTypeMoveSetting(itemType, value) end,
-            disabled = PABMenuFunctions.isFurnishingTransactionMenuDisabled,
-            default = PABMenuDefaults.Crafting.ItemTypes[itemType].moveMode,
+            disabled = function() return not PABMenuFunctions.getCraftingItemsEnabledSetting() end,
+            default = PABMenuDefaults.Crafting.ItemTypes[itemType],
         })
     end
 end

--- a/PersonalAssistant/PersonalAssistantBanking/Menu/PABankingMenuDefaults.lua
+++ b/PersonalAssistant/PersonalAssistantBanking/Menu/PABankingMenuDefaults.lua
@@ -31,128 +31,40 @@ local PABankingMenuDefaults = {
         craftingItemsEnabled = true,
 
         ItemTypes = {
-            [ITEMTYPE_BLACKSMITHING_RAW_MATERIAL] = {
-                enabledSetting = "blacksmithingEnabled",
-                moveMode = PAC.MOVE.IGNORE,
-            },
-            [ITEMTYPE_BLACKSMITHING_MATERIAL] = {
-                enabledSetting = "blacksmithingEnabled",
-                moveMode = PAC.MOVE.IGNORE,
-            },
-            [ITEMTYPE_BLACKSMITHING_BOOSTER] = {
-                enabledSetting = "blacksmithingEnabled",
-                moveMode = PAC.MOVE.IGNORE,
-            },
+            [ITEMTYPE_BLACKSMITHING_RAW_MATERIAL] = PAC.MOVE.IGNORE,
+            [ITEMTYPE_BLACKSMITHING_MATERIAL] = PAC.MOVE.IGNORE,
+            [ITEMTYPE_BLACKSMITHING_BOOSTER] = PAC.MOVE.IGNORE,
 
-            [ITEMTYPE_CLOTHIER_RAW_MATERIAL] = {
-                enabledSetting = "clothingEnabled",
-                moveMode = PAC.MOVE.IGNORE,
-            },
-            [ITEMTYPE_CLOTHIER_MATERIAL] = {
-                enabledSetting = "clothingEnabled",
-                moveMode = PAC.MOVE.IGNORE,
-            },
-            [ITEMTYPE_CLOTHIER_BOOSTER] = {
-                enabledSetting = "clothingEnabled",
-                moveMode = PAC.MOVE.IGNORE,
-            },
+            [ITEMTYPE_CLOTHIER_RAW_MATERIAL] = PAC.MOVE.IGNORE,
+            [ITEMTYPE_CLOTHIER_MATERIAL] = PAC.MOVE.IGNORE,
+            [ITEMTYPE_CLOTHIER_BOOSTER] = PAC.MOVE.IGNORE,
 
-            [ITEMTYPE_WOODWORKING_RAW_MATERIAL] = {
-                enabledSetting = "woodworkingEnabled",
-                moveMode = PAC.MOVE.IGNORE,
-            },
-            [ITEMTYPE_WOODWORKING_MATERIAL] = {
-                enabledSetting = "woodworkingEnabled",
-                moveMode = PAC.MOVE.IGNORE,
-            },
-            [ITEMTYPE_WOODWORKING_BOOSTER] = {
-                enabledSetting = "woodworkingEnabled",
-                moveMode = PAC.MOVE.IGNORE,
-            },
+            [ITEMTYPE_WOODWORKING_RAW_MATERIAL] = PAC.MOVE.IGNORE,
+            [ITEMTYPE_WOODWORKING_MATERIAL] = PAC.MOVE.IGNORE,
+            [ITEMTYPE_WOODWORKING_BOOSTER] = PAC.MOVE.IGNORE,
 
-            [ITEMTYPE_JEWELRYCRAFTING_RAW_MATERIAL] = {
-                enabledSetting = "jewelcraftingEnabled",
-                moveMode = PAC.MOVE.IGNORE,
-            },
-            [ITEMTYPE_JEWELRYCRAFTING_MATERIAL] = {
-                enabledSetting = "jewelcraftingEnabled",
-                moveMode = PAC.MOVE.IGNORE,
-            },
-            [ITEMTYPE_JEWELRYCRAFTING_BOOSTER] = {
-                enabledSetting = "jewelcraftingEnabled",
-                moveMode = PAC.MOVE.IGNORE,
-            },
+            [ITEMTYPE_JEWELRYCRAFTING_RAW_MATERIAL] = PAC.MOVE.IGNORE,
+            [ITEMTYPE_JEWELRYCRAFTING_MATERIAL] = PAC.MOVE.IGNORE,
+            [ITEMTYPE_JEWELRYCRAFTING_BOOSTER] = PAC.MOVE.IGNORE,
 
-            [ITEMTYPE_REAGENT] = {
-                enabledSetting = "alchemyEnabled",
-                moveMode = PAC.MOVE.IGNORE,
-            },
-            [ITEMTYPE_POISON_BASE] = {
-                enabledSetting = "alchemyEnabled",
-                moveMode = PAC.MOVE.IGNORE,
-            },
-            [ITEMTYPE_POTION_BASE] = {
-                enabledSetting = "alchemyEnabled",
-                moveMode = PAC.MOVE.IGNORE,
-            },
+            [ITEMTYPE_REAGENT] = PAC.MOVE.IGNORE,
+            [ITEMTYPE_POISON_BASE] = PAC.MOVE.IGNORE,
+            [ITEMTYPE_POTION_BASE] = PAC.MOVE.IGNORE,
 
-            [ITEMTYPE_ENCHANTING_RUNE_ASPECT] = {
-                enabledSetting = "enchantingEnabled",
-                moveMode = PAC.MOVE.IGNORE,
-            },
-            [ITEMTYPE_ENCHANTING_RUNE_ESSENCE] = {
-                enabledSetting = "enchantingEnabled",
-                moveMode = PAC.MOVE.IGNORE,
-            },
-            [ITEMTYPE_ENCHANTING_RUNE_POTENCY] = {
-                enabledSetting = "enchantingEnabled",
-                moveMode = PAC.MOVE.IGNORE,
-            },
+            [ITEMTYPE_ENCHANTING_RUNE_ASPECT] = PAC.MOVE.IGNORE,
+            [ITEMTYPE_ENCHANTING_RUNE_ESSENCE] = PAC.MOVE.IGNORE,
+            [ITEMTYPE_ENCHANTING_RUNE_POTENCY] = PAC.MOVE.IGNORE,
 
-            [ITEMTYPE_INGREDIENT] = {
-                enabledSetting = "provisioningEnabled",
-                moveMode = PAC.MOVE.IGNORE,
-            },
-            [ITEMTYPE_LURE] = {
-                enabledSetting = "provisioningEnabled",
-                moveMode = PAC.MOVE.IGNORE,
-            },
+            [ITEMTYPE_INGREDIENT] = PAC.MOVE.IGNORE,
+            [ITEMTYPE_LURE] = PAC.MOVE.IGNORE,
 
-            [ITEMTYPE_RAW_MATERIAL] = {
-                enabledSetting = "styleMaterialsEnabled",
-                moveMode = PAC.MOVE.IGNORE,
-            },
-            [ITEMTYPE_STYLE_MATERIAL] = {
-                enabledSetting = "styleMaterialsEnabled",
-                moveMode = PAC.MOVE.IGNORE,
-            },
+            [ITEMTYPE_RAW_MATERIAL] = PAC.MOVE.IGNORE,
+            [ITEMTYPE_STYLE_MATERIAL] = PAC.MOVE.IGNORE,
 
-            [ITEMTYPE_ARMOR_TRAIT] = {
-                enabledSetting = "traitItemsEnabled",
-                moveMode = PAC.MOVE.IGNORE,
-            },
-            [ITEMTYPE_WEAPON_TRAIT] = {
-                enabledSetting = "traitItemsEnabled",
-                moveMode = PAC.MOVE.IGNORE,
-            },
+            [ITEMTYPE_ARMOR_TRAIT] = PAC.MOVE.IGNORE,
+            [ITEMTYPE_WEAPON_TRAIT] = PAC.MOVE.IGNORE,
 
-            [ITEMTYPE_FURNISHING_MATERIAL] = {
-                enabledSetting = "furnishingEnabled",
-                moveMode = PAC.MOVE.IGNORE,
-            },
-        },
-
-        TransactionSettings = {
-            blacksmithingEnabled = true,
-            clothingEnabled = true,
-            woodworkingEnabled = true,
-            jewelcraftingEnabled = true,
-            alchemyEnabled = true,
-            enchantingEnabled = true,
-            provisioningEnabled = true,
-            styleMaterialsEnabled = true,
-            traitItemsEnabled = true,
-            furnishingEnabled = true,
+            [ITEMTYPE_FURNISHING_MATERIAL] = PAC.MOVE.IGNORE,
         },
     },
 

--- a/PersonalAssistant/PersonalAssistantBanking/Menu/PABankingMenuFunctions.lua
+++ b/PersonalAssistant/PersonalAssistantBanking/Menu/PABankingMenuFunctions.lua
@@ -124,21 +124,36 @@ end
 ---------------------------------
 local function getPABankingCraftingItemTypeMoveSetting(itemType)
     if isDisabledPAGeneralNoProfileSelected() then return end
-    return PAB.SavedVars.Crafting.ItemTypes[itemType].moveMode
+    return PAB.SavedVars.Crafting.ItemTypes[itemType]
 end
 
 local function setPABankingCraftingItemTypeMoveSetting(itemType, value)
     if isDisabledPAGeneralNoProfileSelected() then return end
-    PAB.SavedVars.Crafting.ItemTypes[itemType].moveMode = value
+    PAB.SavedVars.Crafting.ItemTypes[itemType] = value
 end
 
 local function setPABankingCraftingItemTypeMoveAllSettings(value)
     if isDisabledPAGeneralNoProfileSelected() then return end
     for itemType, _ in pairs(PAB.SavedVars.Crafting.ItemTypes) do
-        PAB.SavedVars.Crafting.ItemTypes[itemType].moveMode = value
+        PAB.SavedVars.Crafting.ItemTypes[itemType] = value
     end
     PERSONALASSISTANT_PAB_CRAFTING_GLOBAL_MOVE_MODE:UpdateValue()
     -- TODO: chat-message do inform user?
+end
+
+--------------------------------------------------------------------------
+-- PABanking   Crafting.ItemTypes         moveMode
+---------------------------------
+local function isCraftingItemsDisabledOrAllItemTypesMoveModeIgnore(...)
+    if isDisabled({"Crafting", "craftingItemsEnabled"}) then return true end
+
+    -- if savedVarsArgs is not disabled, check the itemTypes
+    local args = { ... }
+    for _, itemType in ipairs(args) do
+        if PAB.SavedVars.Crafting.ItemTypes[itemType] ~= PAC.MOVE.IGNORE then return false end
+    end
+    -- if there was no 'false' returned until here; then return true
+    return true
 end
 
 --------------------------------------------------------------------------
@@ -363,55 +378,16 @@ local PABankingMenuFunctions = {
     getCraftingItemTypeMoveSetting = getPABankingCraftingItemTypeMoveSetting,
     setCraftingItemTypeMoveSetting = setPABankingCraftingItemTypeMoveSetting,
 
-    isBlacksmithingTransactionMenuDisabled = function() return isDisabled({"Crafting", "craftingItemsEnabled"}, {"Crafting", "TransactionSettings", "blacksmithingEnabled"}) end,
-    isBlacksmithingTransactionDisabled = function() return isDisabled({"Crafting", "craftingItemsEnabled"}) end,
-    getBlacksmithingTransactionSetting = function() return getValue({"Crafting", "TransactionSettings", "blacksmithingEnabled"}) end,
-    setBlacksmithingTransactionSetting = function(value) setValue(value, {"Crafting", "TransactionSettings", "blacksmithingEnabled"}) end,
-
-    isClothingTransactionMenuDisabled = function() return isDisabled({"Crafting", "craftingItemsEnabled"}, {"Crafting", "TransactionSettings", "clothingEnabled"}) end,
-    isClothingTransactionDisabled = function() return isDisabled({"Crafting", "craftingItemsEnabled"}) end,
-    getClothingTransactionSetting = function() return getValue({"Crafting", "TransactionSettings", "clothingEnabled"}) end,
-    setClothingTransactionSetting = function(value) setValue(value, {"Crafting", "TransactionSettings", "clothingEnabled"}) end,
-
-    isWoodworkingTransactionMenuDisabled = function() return isDisabled({"Crafting", "craftingItemsEnabled"}, {"Crafting", "TransactionSettings", "woodworkingEnabled"}) end,
-    isWoodworkingTransactionDisabled = function() return isDisabled({"Crafting", "craftingItemsEnabled"}) end,
-    getWoodworkingTransactionSetting = function() return getValue({"Crafting", "TransactionSettings", "woodworkingEnabled"}) end,
-    setWoodworkingTransactionSetting = function(value) setValue(value, {"Crafting", "TransactionSettings", "woodworkingEnabled"}) end,
-
-    isJewelcraftingTransactionMenuDisabled = function() return isDisabled({"Crafting", "craftingItemsEnabled"}, {"Crafting", "TransactionSettings", "jewelcraftingEnabled"}) end,
-    isJewelcraftingTransactionDisabled = function() return isDisabled({"Crafting", "craftingItemsEnabled"}) end,
-    getJewelcraftingTransactionSetting = function() return getValue({"Crafting", "TransactionSettings", "jewelcraftingEnabled"}) end,
-    setJewelcraftingTransactionSetting = function(value) setValue(value, {"Crafting", "TransactionSettings", "jewelcraftingEnabled"}) end,
-
-    isAlchemyTransactionMenuDisabled = function() return isDisabled({"Crafting", "craftingItemsEnabled"}, {"Crafting", "TransactionSettings", "alchemyEnabled"}) end,
-    isAlchemyTransactionDisabled = function() return isDisabled({"Crafting", "craftingItemsEnabled"}) end,
-    getAlchemyTransactionSetting = function() return getValue({"Crafting", "TransactionSettings", "alchemyEnabled"}) end,
-    setAlchemyTransactionSetting = function(value) setValue(value, {"Crafting", "TransactionSettings", "alchemyEnabled"}) end,
-
-    isEnchantingTransactionMenuDisabled = function() return isDisabled({"Crafting", "craftingItemsEnabled"}, {"Crafting", "TransactionSettings", "enchantingEnabled"}) end,
-    isEnchantingTransactionDisabled = function() return isDisabled({"Crafting", "craftingItemsEnabled"}) end,
-    getEnchantingTransactionSetting = function() return getValue({"Crafting", "TransactionSettings", "enchantingEnabled"}) end,
-    setEnchantingTransactionSetting = function(value) setValue(value, {"Crafting", "TransactionSettings", "enchantingEnabled"}) end,
-
-    isProvisioningTransactionMenuDisabled = function() return isDisabled({"Crafting", "craftingItemsEnabled"}, {"Crafting", "TransactionSettings", "provisioningEnabled"}) end,
-    isProvisioningTransactionDisabled = function() return isDisabled({"Crafting", "craftingItemsEnabled"}) end,
-    getProvisioningTransactionSetting = function() return getValue({"Crafting", "TransactionSettings", "provisioningEnabled"}) end,
-    setProvisioningTransactionSetting = function(value) setValue(value, {"Crafting", "TransactionSettings", "provisioningEnabled"}) end,
-
-    isStyleMaterialsTransactionMenuDisabled = function() return isDisabled({"Crafting", "craftingItemsEnabled"}, {"Crafting", "TransactionSettings", "styleMaterialsEnabled"}) end,
-    isStyleMaterialsTransactionDisabled = function() return isDisabled({"Crafting", "craftingItemsEnabled"}) end,
-    getStyleMaterialsTransactionSetting = function() return getValue({"Crafting", "TransactionSettings", "styleMaterialsEnabled"}) end,
-    setStyleMaterialsTransactionSetting = function(value) setValue(value, {"Crafting", "TransactionSettings", "styleMaterialsEnabled"}) end,
-
-    isTraitItemsTransactionMenuDisabled = function() return isDisabled({"Crafting", "craftingItemsEnabled"}, {"Crafting", "TransactionSettings", "traitItemsEnabled"}) end,
-    isTraitItemsTransactionDisabled = function() return isDisabled({"Crafting", "craftingItemsEnabled"}) end,
-    getTraitItemsTransactionSetting = function() return getValue({"Crafting", "TransactionSettings", "traitItemsEnabled"}) end,
-    setTraitItemsTransactionSetting = function(value) setValue(value, {"Crafting", "TransactionSettings", "traitItemsEnabled"}) end,
-
-    isFurnishingTransactionMenuDisabled = function() return isDisabled({"Crafting", "craftingItemsEnabled"}, {"Crafting", "TransactionSettings", "furnishingEnabled"}) end,
-    isFurnishingTransactionDisabled = function() return isDisabled({"Crafting", "craftingItemsEnabled"}) end,
-    getFurnishingTransactionSetting = function() return getValue({"Crafting", "TransactionSettings", "furnishingEnabled"}) end,
-    setFurnishingTransactionSetting = function(value) setValue(value, {"Crafting", "TransactionSettings", "furnishingEnabled"}) end,
+    isBlacksmithingTransactionMenuDisabled = function() return isCraftingItemsDisabledOrAllItemTypesMoveModeIgnore(ITEMTYPE_BLACKSMITHING_RAW_MATERIAL, ITEMTYPE_BLACKSMITHING_MATERIAL, ITEMTYPE_BLACKSMITHING_BOOSTER) end,
+    isClothingTransactionMenuDisabled = function() return isCraftingItemsDisabledOrAllItemTypesMoveModeIgnore(ITEMTYPE_CLOTHIER_RAW_MATERIAL, ITEMTYPE_CLOTHIER_MATERIAL, ITEMTYPE_CLOTHIER_BOOSTER) end,
+    isWoodworkingTransactionMenuDisabled = function() return isCraftingItemsDisabledOrAllItemTypesMoveModeIgnore(ITEMTYPE_WOODWORKING_RAW_MATERIAL, ITEMTYPE_WOODWORKING_MATERIAL, ITEMTYPE_WOODWORKING_BOOSTER) end,
+    isJewelcraftingTransactionMenuDisabled = function() return isCraftingItemsDisabledOrAllItemTypesMoveModeIgnore(ITEMTYPE_JEWELRYCRAFTING_RAW_MATERIAL, ITEMTYPE_JEWELRYCRAFTING_MATERIAL, ITEMTYPE_JEWELRYCRAFTING_BOOSTER) end,
+    isAlchemyTransactionMenuDisabled = function() return isCraftingItemsDisabledOrAllItemTypesMoveModeIgnore(ITEMTYPE_REAGENT, ITEMTYPE_POISON_BASE, ITEMTYPE_POTION_BASE) end,
+    isEnchantingTransactionMenuDisabled = function() return isCraftingItemsDisabledOrAllItemTypesMoveModeIgnore(ITEMTYPE_ENCHANTING_RUNE_ASPECT, ITEMTYPE_ENCHANTING_RUNE_ESSENCE, ITEMTYPE_ENCHANTING_RUNE_POTENCY) end,
+    isProvisioningTransactionMenuDisabled = function() return isCraftingItemsDisabledOrAllItemTypesMoveModeIgnore(ITEMTYPE_INGREDIENT, ITEMTYPE_LURE) end,
+    isStyleMaterialsTransactionMenuDisabled = function() return isCraftingItemsDisabledOrAllItemTypesMoveModeIgnore(ITEMTYPE_RAW_MATERIAL, ITEMTYPE_STYLE_MATERIAL) end,
+    isTraitItemsTransactionMenuDisabled = function() return isCraftingItemsDisabledOrAllItemTypesMoveModeIgnore(ITEMTYPE_ARMOR_TRAIT, ITEMTYPE_WEAPON_TRAIT) end,
+    isFurnishingTransactionMenuDisabled = function() return isCraftingItemsDisabledOrAllItemTypesMoveModeIgnore(ITEMTYPE_FURNISHING_MATERIAL) end,
 
     -- ----------------------------------------------------------------------------------
     -- ADVANCED ITEMS

--- a/PersonalAssistant/PersonalAssistantBanking/PABanking/PABankingCrafting.lua
+++ b/PersonalAssistant/PersonalAssistantBanking/PABanking/PABankingCrafting.lua
@@ -65,18 +65,16 @@ local function depositOrWithdrawCraftingItems()
         local withdrawItemTypes = setmetatable({}, { __index = table })
 
         -- fill up the table
-        for itemType, moveConfig in pairs(PAB.SavedVars.Crafting.ItemTypes) do
-            if PAB.SavedVars.Crafting.TransactionSettings[moveConfig.enabledSetting] then
-                if moveConfig.moveMode == PAC.MOVE.DEPOSIT then
-                    if _passesLazyWritCraftingCompatibilityCheck(itemType) then
-                        depositItemTypes:insert(itemType)
-                    else
-                        _someItemskippedForLWC = true
-                        PAHF.debugln("skip [%s] because of LWC compatibility", GetString("SI_ITEMTYPE", itemType))
-                    end
-                elseif moveConfig.moveMode == PAC.MOVE.WITHDRAW then
-                    withdrawItemTypes:insert(itemType)
+        for itemType, moveMode in pairs(PAB.SavedVars.Crafting.ItemTypes) do
+            if moveMode == PAC.MOVE.DEPOSIT then
+                if _passesLazyWritCraftingCompatibilityCheck(itemType) then
+                    depositItemTypes:insert(itemType)
+                else
+                    _someItemskippedForLWC = true
+                    PAHF.debugln("skip [%s] because of LWC compatibility", GetString("SI_ITEMTYPE", itemType))
                 end
+            elseif moveMode == PAC.MOVE.WITHDRAW then
+                withdrawItemTypes:insert(itemType)
             end
         end
 

--- a/PersonalAssistant/PersonalAssistantBanking/PersonalAssistantBanking.lua
+++ b/PersonalAssistant/PersonalAssistantBanking/PersonalAssistantBanking.lua
@@ -42,7 +42,7 @@ local function initAddon(_, addOnName)
     initDefaults()
 
     -- gets values from SavedVars, or initialises with default values
-    PA.SavedVars.Banking = ZO_SavedVars:NewAccountWide("PersonalAssistantBanking_SavedVariables", 2, nil, Banking_Defaults)
+    PA.SavedVars.Banking = ZO_SavedVars:NewAccountWide("PersonalAssistantBanking_SavedVariables", 3, nil, Banking_Defaults)
 
     -- create the options with LAM-2
     PA.Banking.createOptions()

--- a/PersonalAssistant/PersonalAssistantBanking/localization/de.lua
+++ b/PersonalAssistant/PersonalAssistantBanking/localization/de.lua
@@ -17,17 +17,6 @@ SafeAddString(SI_PA_MENU_BANKING_CRAFTING_ESOPLUS_DESC, table.concat({PAC.COLORS
 SafeAddString(SI_PA_MENU_BANKING_CRAFTING_GLOBAL_MOVEMODE, "Ändere alle obigen Dropdown-Listen nach", 1)
 SafeAddString(SI_PA_MENU_BANKING_CRAFTING_GLOBAL_MOVEMODE_T, "Ändere alle obigen Handwerks Dropdown-Listen nach 'In Truhe einlagern', 'Ins Inventar entnehmen', oder 'Nichts machen'", 1)
 
-SafeAddString(SI_PA_MENU_BANKING_CRAFTING_BLACKSMITHING_ITEMS_ENABLE, table.concat({GetString(SI_PA_MENU_BANKING_CRAFTING_BLACKSMITHING), " Gegenstände einlagern/entnehmen"}), 1)
-SafeAddString(SI_PA_MENU_BANKING_CRAFTING_CLOTHING_ITEMS_ENABLE, table.concat({GetString(SI_PA_MENU_BANKING_CRAFTING_CLOTHING), " Gegenstände einlagern/entnehmen"}), 1)
-SafeAddString(SI_PA_MENU_BANKING_CRAFTING_WOODWORKING_ITEMS_ENABLE, table.concat({GetString(SI_PA_MENU_BANKING_CRAFTING_WOODWORKING), " Gegenstände einlagern/entnehmen"}), 1)
-SafeAddString(SI_PA_MENU_BANKING_CRAFTING_JEWELCRAFTING_ITEMS_ENABLE, table.concat({GetString(SI_PA_MENU_BANKING_CRAFTING_JEWELCRAFTING), " Gegenstände einlagern/entnehmen"}), 1)
-SafeAddString(SI_PA_MENU_BANKING_CRAFTING_ALCHEMY_ITEMS_ENABLE, table.concat({GetString(SI_PA_MENU_BANKING_CRAFTING_ALCHEMY), " Gegenstände einlagern/entnehmen"}), 1)
-SafeAddString(SI_PA_MENU_BANKING_CRAFTING_ENCHANTING_ITEMS_ENABLE, table.concat({GetString(SI_PA_MENU_BANKING_CRAFTING_ENCHANTING), " Gegenstände einlagern/entnehmen"}), 1)
-SafeAddString(SI_PA_MENU_BANKING_CRAFTING_PROVISIONING_ITEMS_ENABLE, table.concat({GetString(SI_PA_MENU_BANKING_CRAFTING_PROVISIONING), " Gegenstände einlagern/entnehmen"}), 1)
-SafeAddString(SI_PA_MENU_BANKING_CRAFTING_STYLEMATERIALS_ITEMS_ENABLE, table.concat({GetString(SI_PA_MENU_BANKING_CRAFTING_STYLEMATERIALS), " Gegenstände einlagern/entnehmen"}), 1)
-SafeAddString(SI_PA_MENU_BANKING_CRAFTING_TRAITITEMS_ITEMS_ENABLE, table.concat({GetString(SI_PA_MENU_BANKING_CRAFTING_TRAITITEMS), " Gegenstände einlagern/entnehmen"}), 1)
-SafeAddString(SI_PA_MENU_BANKING_CRAFTING_FURNISHING_ITEMS_ENABLE, table.concat({GetString(SI_PA_MENU_BANKING_CRAFTING_FURNISHING), " Gegenstände einlagern/entnehmen"}), 1)
-
 SafeAddString(SI_PA_MENU_BANKING_ADVANCED, "Spezielle", 1)
 SafeAddString(SI_PA_MENU_BANKING_ADVANCED_ENABLE, table.concat({PAC.COLORS.LIGHT_BLUE, "Aktiviere Transaktionen für Spezielle Gegenstände"}), 1)
 SafeAddString(SI_PA_MENU_BANKING_ADVANCED_ENABLE_T, "Aktiviere automatisches Einlagern und Entnehmen für die verschiedenen Speziellen Gegenständen", 1)

--- a/PersonalAssistant/PersonalAssistantBanking/localization/en.lua
+++ b/PersonalAssistant/PersonalAssistantBanking/localization/en.lua
@@ -21,17 +21,6 @@ local PABStrings = {
     SI_PA_MENU_BANKING_CRAFTING_GLOBAL_MOVEMODE = "Change all above Crafting Item dropdowns to",
     SI_PA_MENU_BANKING_CRAFTING_GLOBAL_MOVEMODE_T = "Change all above Crafting Item dropdown values to 'Deposit to Bank', 'Withdraw to Backpack, or to 'Do Nothing'",
 
-    SI_PA_MENU_BANKING_CRAFTING_BLACKSMITHING_ITEMS_ENABLE = table.concat({"Deposit/Withdraw ", GetString(SI_PA_MENU_BANKING_CRAFTING_BLACKSMITHING), " Items"}),
-    SI_PA_MENU_BANKING_CRAFTING_CLOTHING_ITEMS_ENABLE = table.concat({"Deposit/Withdraw ", GetString(SI_PA_MENU_BANKING_CRAFTING_CLOTHING), " Items"}),
-    SI_PA_MENU_BANKING_CRAFTING_WOODWORKING_ITEMS_ENABLE = table.concat({"Deposit/Withdraw ", GetString(SI_PA_MENU_BANKING_CRAFTING_WOODWORKING), " Items"}),
-    SI_PA_MENU_BANKING_CRAFTING_JEWELCRAFTING_ITEMS_ENABLE = table.concat({"Deposit/Withdraw ", GetString(SI_PA_MENU_BANKING_CRAFTING_JEWELCRAFTING), " Items"}),
-    SI_PA_MENU_BANKING_CRAFTING_ALCHEMY_ITEMS_ENABLE = table.concat({"Deposit/Withdraw ", GetString(SI_PA_MENU_BANKING_CRAFTING_ALCHEMY), " Items"}),
-    SI_PA_MENU_BANKING_CRAFTING_ENCHANTING_ITEMS_ENABLE = table.concat({"Deposit/Withdraw ", GetString(SI_PA_MENU_BANKING_CRAFTING_ENCHANTING), " Items"}),
-    SI_PA_MENU_BANKING_CRAFTING_PROVISIONING_ITEMS_ENABLE = table.concat({"Deposit/Withdraw ", GetString(SI_PA_MENU_BANKING_CRAFTING_PROVISIONING), " Items"}),
-    SI_PA_MENU_BANKING_CRAFTING_STYLEMATERIALS_ITEMS_ENABLE = table.concat({"Deposit/Withdraw ", GetString(SI_PA_MENU_BANKING_CRAFTING_STYLEMATERIALS)}),
-    SI_PA_MENU_BANKING_CRAFTING_TRAITITEMS_ITEMS_ENABLE = table.concat({"Deposit/Withdraw ", GetString(SI_PA_MENU_BANKING_CRAFTING_TRAITITEMS)}),
-    SI_PA_MENU_BANKING_CRAFTING_FURNISHING_ITEMS_ENABLE = table.concat({"Deposit/Withdraw ", GetString(SI_PA_MENU_BANKING_CRAFTING_FURNISHING)}),
-
     SI_PA_MENU_BANKING_ADVANCED = "Special",
     SI_PA_MENU_BANKING_ADVANCED_ENABLE = table.concat({PAC.COLORS.LIGHT_BLUE, "Enable Auto Banking for Special Items"}),
     SI_PA_MENU_BANKING_ADVANCED_ENABLE_T = "Enable Auto Bank Deposit and Withdrawal for the different Special Items?",

--- a/PersonalAssistant/PersonalAssistantBanking/localization/fr.lua
+++ b/PersonalAssistant/PersonalAssistantBanking/localization/fr.lua
@@ -17,17 +17,6 @@ SafeAddString(SI_PA_MENU_BANKING_CRAFTING_ESOPLUS_DESC, table.concat({PAC.COLORS
 SafeAddString(SI_PA_MENU_BANKING_CRAFTING_GLOBAL_MOVEMODE, "Changer tous les menus des objets d'artisanat en :", 1)
 SafeAddString(SI_PA_MENU_BANKING_CRAFTING_GLOBAL_MOVEMODE_T, "Changer tous les menus des objets d'artisanat précédents en 'Déposer en banque', 'Prendre dans le sac', ou 'Ne rien faire'", 1)
 
-SafeAddString(SI_PA_MENU_BANKING_CRAFTING_BLACKSMITHING_ITEMS_ENABLE, table.concat({"Déposer/Retirer les matériaux de ", GetString(SI_PA_MENU_BANKING_CRAFTING_BLACKSMITHING)}), 1)
-SafeAddString(SI_PA_MENU_BANKING_CRAFTING_CLOTHING_ITEMS_ENABLE, table.concat({"Déposer/Retirer les matériaux de ", GetString(SI_PA_MENU_BANKING_CRAFTING_CLOTHING)}), 1)
-SafeAddString(SI_PA_MENU_BANKING_CRAFTING_WOODWORKING_ITEMS_ENABLE, table.concat({"Déposer/Retirer les matériaux de ", GetString(SI_PA_MENU_BANKING_CRAFTING_WOODWORKING)}), 1)
-SafeAddString(SI_PA_MENU_BANKING_CRAFTING_JEWELCRAFTING_ITEMS_ENABLE, table.concat({"Déposer/Retirer les matériaux de ", GetString(SI_PA_MENU_BANKING_CRAFTING_JEWELCRAFTING)}), 1)
-SafeAddString(SI_PA_MENU_BANKING_CRAFTING_ALCHEMY_ITEMS_ENABLE, table.concat({"Déposer/Retirer les matériaux d'", GetString(SI_PA_MENU_BANKING_CRAFTING_ALCHEMY)}), 1)
-SafeAddString(SI_PA_MENU_BANKING_CRAFTING_ENCHANTING_ITEMS_ENABLE, table.concat({"Déposer/Retirer les matériaux d'", GetString(SI_PA_MENU_BANKING_CRAFTING_ENCHANTING)}), 1)
-SafeAddString(SI_PA_MENU_BANKING_CRAFTING_PROVISIONING_ITEMS_ENABLE, table.concat({"Déposer/Retirer les matériaux de ", GetString(SI_PA_MENU_BANKING_CRAFTING_PROVISIONING)}), 1)
-SafeAddString(SI_PA_MENU_BANKING_CRAFTING_STYLEMATERIALS_ITEMS_ENABLE, table.concat({"Déposer/Retirer les ", GetString(SI_PA_MENU_BANKING_CRAFTING_STYLEMATERIALS)}), 1)
-SafeAddString(SI_PA_MENU_BANKING_CRAFTING_TRAITITEMS_ITEMS_ENABLE, table.concat({"Déposer/Retirer les ", GetString(SI_PA_MENU_BANKING_CRAFTING_TRAITITEMS)}), 1)
-SafeAddString(SI_PA_MENU_BANKING_CRAFTING_FURNISHING_ITEMS_ENABLE, table.concat({"Déposer/Retirer les matériaux d'", GetString(SI_PA_MENU_BANKING_CRAFTING_FURNISHING)}), 1)
-
 SafeAddString(SI_PA_MENU_BANKING_ADVANCED, "Spécial", 1)
 SafeAddString(SI_PA_MENU_BANKING_ADVANCED_ENABLE, table.concat({PAC.COLORS.LIGHT_BLUE, "Dépot/Retrait automatique des objets spéciaux"}), 1)
 SafeAddString(SI_PA_MENU_BANKING_ADVANCED_ENABLE_T, "Activer la mise en banque ou le retrait automatique pour les objets spéciaux ?", 1)


### PR DESCRIPTION
Removing the ON/OFF toggles from the crafting bag items and have the same disabling logic like for the Advanced items, solely based on dropdown selection.

This resolves #37 and implicetly also resolves #36 because the toggles that caused the problem are no longer existing.