### PR TITLE
Russian localization for version 2.4.5

### DIFF
--- a/PersonalAssistant/PersonalAssistant.lua
+++ b/PersonalAssistant/PersonalAssistant.lua
@@ -131,7 +131,7 @@ local function introduction()
         if showWelcomeMessage and PAGSavedVars.welcome then
             showWelcomeMessage = false
             local currLanguage = GetCVar("language.2") or "en"
-            if currLanguage ~= "en" and currLanguage ~= "de" and currLanguage ~= "fr" then
+            if currLanguage ~= "en" and currLanguage ~= "de" and currLanguage ~= "fr"  and currLanguage ~= "ru" then
                 PA.println(SI_PA_WELCOME_NO_SUPPORT, currLanguage)
             else
                 PA.println(SI_PA_WELCOME_SUPPORT)

--- a/PersonalAssistant/PersonalAssistantBanking/localization/de.lua
+++ b/PersonalAssistant/PersonalAssistantBanking/localization/de.lua
@@ -25,7 +25,7 @@ SafeAddString(SI_PA_MENU_BANKING_ADVANCED_HEADER, "Spezielle Gegenstände", 1)
 SafeAddString(SI_PA_MENU_BANKING_ADVANCED_ENABLE, "Aktiviere Transaktionen für Spezielle Gegenstände", 1)
 SafeAddString(SI_PA_MENU_BANKING_ADVANCED_ENABLE_T, "Aktiviere automatisches Einlagern und Entnehmen für die verschiedenen Speziellen Gegenständen?", 1)
 SafeAddString(SI_PA_MENU_BANKING_ADVANCED_DESCRIPTION, "Definiere ein individuelles Verhalten (Einlagern, Entnehmen, oder Nichts machen) für spezielle Gegenstände", 1)
-SafeAddString(SI_PA_MENU_BANKING_ADVANCED_GLYPHS, "Glyphen", 1) -- TODO: to be checked why this is not replacing the English text
+
 SafeAddString(SI_PA_MENU_BANKING_ADVANCED_GLOBAL_MOVEMODE, "Ändere alle obigen Dropdown-Listen nach", 1)
 SafeAddString(SI_PA_MENU_BANKING_ADVANCED_GLOBAL_MOVEMODE_T, "Ändere alle obigen Speziellen Dropdown-Listen nach 'In Truhe einlagern', 'Ins Inventar entnehmen', oder 'Nichts machen'", 1)
 

--- a/PersonalAssistant/PersonalAssistantBanking/localization/en.lua
+++ b/PersonalAssistant/PersonalAssistantBanking/localization/en.lua
@@ -29,7 +29,7 @@ local PABStrings = {
     SI_PA_MENU_BANKING_ADVANCED_ENABLE = "Enable Auto Banking for Special Items",
     SI_PA_MENU_BANKING_ADVANCED_ENABLE_T = "Enable Auto Bank Deposit and Withdrawal for the different Special Items?",
     SI_PA_MENU_BANKING_ADVANCED_DESCRIPTION = "Define an individual behaviour (deposit, withdraw, or do nothing) for Special Items",
-    SI_PA_MENU_BANKING_ADVANCED_GLYPHS = "Glyphs",
+
     SI_PA_MENU_BANKING_ADVANCED_GLOBAL_MOVEMODE = "Change all above Special Item dropdowns to",
     SI_PA_MENU_BANKING_ADVANCED_GLOBAL_MOVEMODE_T = "Change all above Special Item dropdown values to 'Deposit to Bank', 'Withdraw to Backpack, or to 'Do Nothing'",
 

--- a/PersonalAssistant/PersonalAssistantBanking/localization/fr.lua
+++ b/PersonalAssistant/PersonalAssistantBanking/localization/fr.lua
@@ -25,7 +25,7 @@ SafeAddString(SI_PA_MENU_BANKING_ADVANCED_HEADER, "Objets spéciaux", 1)
 SafeAddString(SI_PA_MENU_BANKING_ADVANCED_ENABLE, "Dépot/Retrait automatique des objets spéciaux", 1)
 SafeAddString(SI_PA_MENU_BANKING_ADVANCED_ENABLE_T, "Activer la mise en banque ou le retrait automatique pour les objets spéciaux ?", 1)
 SafeAddString(SI_PA_MENU_BANKING_ADVANCED_DESCRIPTION, "Définir l'action à exécuter (dépose, retrait, aucune action) pour les objets spéciaux", 1)
-SafeAddString(SI_PA_MENU_BANKING_ADVANCED_GLYPHS, "Glyphes", 1) -- TODO: to be checked why this is not replacing the English text
+
 SafeAddString(SI_PA_MENU_BANKING_ADVANCED_GLOBAL_MOVEMODE, "Changer tous les menus des objets spéciaux en :", 1)
 SafeAddString(SI_PA_MENU_BANKING_ADVANCED_GLOBAL_MOVEMODE_T, "Changer tous les menus des objets spéciaux précédents en 'Déposer en banque', 'Prendre dans le sac', ou 'Ne rien faire'", 1)
 

--- a/PersonalAssistant/PersonalAssistantBanking/localization/ru.lua
+++ b/PersonalAssistant/PersonalAssistantBanking/localization/ru.lua
@@ -1,0 +1,107 @@
+local PAC = PersonalAssistant.Constants
+-- =================================================================================================================
+-- Language specific texts that need to be translated --
+
+-- =================================================================================================================
+-- == MENU/PANEL TEXTS == --
+-- -----------------------------------------------------------------------------------------------------------------
+-- PABanking Menu --
+SafeAddString(SI_PA_MENU_BANKING_DESCRIPTION, "PABanking может перемещать валюты, ремесленные и прочие предметы между банком и инвентарём персонажа", 1)
+
+-- Currencies --
+SafeAddString(SI_PA_MENU_BANKING_CURRENCY_HEADER, "Валюты", 1)
+SafeAddString(SI_PA_MENU_BANKING_CURRENCY_ENABLE, "Включить перемещение валют", 1)
+SafeAddString(SI_PA_MENU_BANKING_CURRENCY_MINTOKEEP, "Минимальный остаток у персонажа", 1)
+SafeAddString(SI_PA_MENU_BANKING_CURRENCY_MAXTOKEEP, "Максимальный остаток у персонажа", 1)
+
+
+-- Crafting Items --
+SafeAddString(SI_PA_MENU_BANKING_CRAFTING_HEADER, "Ремесло", 1)
+SafeAddString(SI_PA_MENU_BANKING_CRAFTING_ENABLE, "Включить перемещение ремесленных предметов", 1)
+SafeAddString(SI_PA_MENU_BANKING_CRAFTING_ENABLE_T, "Включить перемещение между инвентарём и банком ремесленных предметов.", 1)
+SafeAddString(SI_PA_MENU_BANKING_CRAFTING_DESCRIPTION, "Задать индивидуальные правила (положить, изъять или игнорировать) для ремесленных предметов", 1)
+SafeAddString(SI_PA_MENU_BANKING_CRAFTING_ESOPLUS_DESC, "У вас есть подписка ESO Plus, внесение/снятие ремесленных предметов не имеет смысла, поскольку они автоматически попадают в бесконечную ремесленную сумку.", 1)
+SafeAddString(SI_PA_MENU_BANKING_CRAFTING_GLOBAL_MOVEMODE, "Заменить правила для всех крафтовых предметов", 1)
+SafeAddString(SI_PA_MENU_BANKING_CRAFTING_GLOBAL_MOVEMODE_T, "Заменить правила для всех крафтовых предметов на 'Переместить в банк', 'Переместить в инвентарь' или 'Ничего не делать'", 1)
+
+-- Advanced Items --
+SafeAddString(SI_PA_MENU_BANKING_ADVANCED_HEADER, "Особые предметы", 1)
+SafeAddString(SI_PA_MENU_BANKING_ADVANCED_ENABLE, "Включить перемещение", 1)
+SafeAddString(SI_PA_MENU_BANKING_ADVANCED_ENABLE_T, "Включить перемещение между инвентарём и банком особых предметов.", 1)
+SafeAddString(SI_PA_MENU_BANKING_ADVANCED_DESCRIPTION, "Задать индивидуальные правила (переместить в банк, переместить в инвентарь или ничего не делать) для особых предметов", 1)
+
+SafeAddString(SI_PA_MENU_BANKING_ADVANCED_GLOBAL_MOVEMODE, "Заменить правила для всех особых предметов", 1)
+SafeAddString(SI_PA_MENU_BANKING_ADVANCED_GLOBAL_MOVEMODE_T, "Заменить правила для всех особых предметов на 'Переместить в банк', 'Переместить в инвентарь' или 'Ничего не делать'", 1)
+
+SafeAddString(SI_PA_MENU_BANKING_ADVANCED_KNOWN_ITEMTYPE8, table.concat({PAC.ICONS.OTHERS.KNOWN.NORMAL, " Известные мотивы"}), 1)
+SafeAddString(SI_PA_MENU_BANKING_ADVANCED_KNOWN_ITEMTYPE29, table.concat({PAC.ICONS.OTHERS.KNOWN.NORMAL, " Известные рецепты"}), 1)
+SafeAddString(SI_PA_MENU_BANKING_ADVANCED_UNKNOWN_ITEMTYPE8, table.concat({PAC.ICONS.OTHERS.UNKNOWN.NORMAL, " Неизвестные мотивы"}), 1)
+SafeAddString(SI_PA_MENU_BANKING_ADVANCED_UNKNOWN_ITEMTYPE29, table.concat({PAC.ICONS.OTHERS.UNKNOWN.NORMAL, " Неизвестные рецепты"}), 1)
+
+-- Individual Items --
+SafeAddString(SI_PA_MENU_BANKING_INDIVIDUAL_HEADER, "Настраиваемые предметы", 1)
+SafeAddString(SI_PA_MENU_BANKING_INDIVIDUAL_ENABLE, "Включить перемещение", 1)
+SafeAddString(SI_PA_MENU_BANKING_INDIVIDUAL_DISABLED_DESCRIPTION, table.concat({"С введением настраиваемых банковских правил, \"Настраиваемые предметы\" были перенесены туда. ", GetString(SI_PA_MENU_RULES_HOW_TO_ADD_PAB), "\n\n", GetString(SI_PA_MENU_RULES_HOW_TO_FIND_MENU)}), 1)
+
+-- AvA Items --
+SafeAddString(SI_PA_MENU_BANKING_AVA_HEADER, "Война альянсов", 1)
+SafeAddString(SI_PA_MENU_BANKING_AVA_ENABLE, "Включить перемещение", 1)
+SafeAddString(SI_PA_MENU_BANKING_AVA_ENABLE_T, "Включить перемещение между инвентарём и банком предметов войны альянсов.", 1)
+SafeAddString(SI_PA_MENU_BANKING_AVA_DESCRIPTION, "Укажите количество различных предметов войны альянсов которые вы хотите оставить в инвентаре", 1)
+SafeAddString(SI_PA_MENU_BANKING_AVA_OTHER_HEADER, "Прочее", 1)
+
+-- Other Settings --
+SafeAddString(SI_PA_MENU_BANKING_OTHER_DEPOSIT_STACKING, "Правила объединения при внесении", 1)
+SafeAddString(SI_PA_MENU_BANKING_OTHER_DEPOSIT_STACKING_T, "Определяет будут ли все выбранные предметы перемещены в банк или только лишь дополнены имеющиеся там стеки", 1)
+SafeAddString(SI_PA_MENU_BANKING_OTHER_WITHDRAWAL_STACKING, "Правила объединения при изъятии", 1)
+SafeAddString(SI_PA_MENU_BANKING_OTHER_WITHDRAWAL_STACKING_T, "Определяет будут ли все выбранные предметы перемещены в инвентарь или только лишь дополнены имеющиеся там стеки", 1)
+
+SafeAddString(SI_PA_MENU_BANKING_OTHER_AUTOSTACKBAGS, "Складывать все предметы в стеки при открытии банка", 1)
+SafeAddString(SI_PA_MENU_BANKING_OTHER_AUTOSTACKBAGS_T, "Автоматически складывать все предметы в стеки в банке и инвентаре при открытии банка. Помогает эффективнее использовать место", 1)
+
+-- Generic definitions for any type --
+SafeAddString(SI_PA_MENU_BANKING_ANY_CURRENCY_ENABLE, "Перемещать %s", 1)
+
+SafeAddString(SI_PA_MENU_BANKING_ANY_KEEPINBACKPACK, "Оставлять", 1)
+SafeAddString(SI_PA_MENU_BANKING_ANY_KEEPINBACKPACK_T, "Определяет количество (основанное на операторе), которое оставляется в банке или инвентаре", 1)
+
+SafeAddString(SI_PA_MENU_BANKING_ANY_MINTOKEEP_T, "Минимальное количество в инвентаре у персонажа; если требуется, %s изымаются из банка", 1)
+SafeAddString(SI_PA_MENU_BANKING_ANY_MAXTOKEEP_T, "Максимальное количество в инвентаре у персонажа; %s сверх этого количества перемещается в банк", 1)
+
+SafeAddString(SI_PA_MENU_BANKING_ANY_GLOBAL_MOVEMODE_W, "Не может быть отменено. Все индивидуально заданные значения будут сброшены", 1)
+
+
+-- =================================================================================================================
+-- == MAIN MENU TEXTS == --
+-- -----------------------------------------------------------------------------------------------------------------
+-- PABanking --
+SafeAddString(SI_PA_MAINMENU_BANKING_HEADER, "Банковские правила", 1)
+
+SafeAddString(SI_PA_MAINMENU_BANKING_HEADER_BAG, "Расположение", 1)
+SafeAddString(SI_PA_MAINMENU_BANKING_HEADER_OPERATOR, "Оператор", 1)
+SafeAddString(SI_PA_MAINMENU_BANKING_HEADER_AMOUNT, "Количество", 1)
+SafeAddString(SI_PA_MAINMENU_BANKING_HEADER_ITEM, "Предмет", 1)
+SafeAddString(SI_PA_MAINMENU_BANKING_HEADER_ACTIONS, "Действия", 1)
+
+
+-- =================================================================================================================
+-- == CHAT OUTPUTS == --
+-- -----------------------------------------------------------------------------------------------------------------
+-- PABanking --
+SafeAddString(SI_PA_CHAT_BANKING_WITHDRAWAL_COMPLETE, "%s изъято", 1)
+SafeAddString(SI_PA_CHAT_BANKING_WITHDRAWAL_PARTIAL_SOURCE, "%s / %s изъято (Банк пуст)", 1)
+SafeAddString(SI_PA_CHAT_BANKING_WITHDRAWAL_PARTIAL_TARGET, "%s / %s %s изъято (Нет места в инвентаре)", 1)
+
+SafeAddString(SI_PA_CHAT_BANKING_DEPOSIT_COMPLETE, "%s внесено", 1)
+SafeAddString(SI_PA_CHAT_BANKING_DEPOSIT_PARTIAL_SOURCE, "%s / %s внесено (Инвентарь пуст)", 1)
+SafeAddString(SI_PA_CHAT_BANKING_DEPOSIT_PARTIAL_TARGET, "%s / %s внесено (Нет места в банке)", 1)
+
+SafeAddString(SI_PA_CHAT_BANKING_ITEMS_MOVED_COMPLETE, "%d x %s перемещено в %s", 1)
+SafeAddString(SI_PA_CHAT_BANKING_ITEMS_MOVED_PARTIAL, "%d/%d x %s перемещено в %s", 1)
+SafeAddString(SI_PA_CHAT_BANKING_ITEMS_NOT_MOVED_OUTOFSPACE, "Невозможно переместить %s в %s. Нет места!", 1)
+SafeAddString(SI_PA_CHAT_BANKING_ITEMS_NOT_MOVED_BANKCLOSED, "Невозможно переместить %s в %s. Окно было закрыто!", 1)
+SafeAddString(SI_PA_CHAT_BANKING_ITEMS_SKIPPED_LWC, "Некоторые предметы НЕ БЫЛИ перемещены, чтоб предотвратить потенциальные коллизии с Dolgubon's Lazy Writ Crafter", 1)
+
+SafeAddString(SI_PA_CHAT_BANKING_RULES_ADDED, table.concat({"Правило для %s было ", PAC.COLOR.ORANGE:Colorize("добавлено"), "!"}), 1)
+SafeAddString(SI_PA_CHAT_BANKING_RULES_UPDATED, table.concat({"Правило для %s было ", PAC.COLOR.ORANGE:Colorize("обновлено"), "!"}), 1)
+SafeAddString(SI_PA_CHAT_BANKING_RULES_DELETED, table.concat({"Правило для %s было ", PAC.COLOR.ORANGE:Colorize("удалено"), "!"}), 1)

--- a/PersonalAssistant/PersonalAssistantIntegration/localization/ru.lua
+++ b/PersonalAssistant/PersonalAssistantIntegration/localization/ru.lua
@@ -1,0 +1,37 @@
+-- =================================================================================================================
+-- Language specific texts that need to be translated --
+
+-- =================================================================================================================
+-- == MENU/PANEL TEXTS == --
+-- -----------------------------------------------------------------------------------------------------------------
+-- PAIntegration Menu --
+SafeAddString(SI_PA_MENU_INTEGRATION_DESCRIPTION, "PAIntegration позволяет использовать в дополнении PersonalAssistant функциональные возможности прочих дополнений, таких как Dolgubon's Lazy Writ Crafter или FCO ItemSaver", 1)
+SafeAddString(SI_PA_MENU_INTEGRATION_NOTHING_AVAILABLE, "В настоящее время у вас нет установленных/включенных дополнений, которые поддерживаются PAIntegration", 1)
+
+-- Dolgubon's Lazy Writ Crafter --
+SafeAddString(SI_PA_MENU_INTEGRATION_LWC_PRECONDITION, "Примечание: чтобы использовать приведенные ниже настройки, необходимо сначала включить PABanking", 1)
+
+SafeAddString(SI_PA_MENU_INTEGRATION_LWC_COMPATIBILITY, "Совместимость с Dolgubon's Lazy Writ Crafter", 1)
+SafeAddString(SI_PA_MENU_INTEGRATION_LWC_COMPATIBILITY_T, "Если у вас есть активные мастерские заказы и включено изъятие предметов в «Dolgubon's Lazy Writ Crafter», тогда для этих предметов параметр «Переместить в банк» игнорируется. Это необходимо для того, чтобы избежать немедленного повторного перемещения в банк снятых предметов", 1)
+
+-- FCO ItemSaver --
+SafeAddString(SI_PA_MENU_INTEGRATION_FCOIS_PRECONDITION, "Примечание: чтобы использовать приведенные ниже настройки, необходимо сначала включить PAJunk", 1)
+
+SafeAddString(SI_PA_MENU_INTEGRATION_FCOIS_LOCKED_PREVENT_SELLING, "Не продавать заблокированные предметы", 1)
+SafeAddString(SI_PA_MENU_INTEGRATION_FCOIS_SELL_AUTOSELL_MARKED, "Продавать предметы отмеченные для продажи", 1)
+
+
+-- =================================================================================================================
+-- == CHAT OUTPUTS == --
+-- -----------------------------------------------------------------------------------------------------------------
+-- PAIntegration --
+
+
+-- =================================================================================================================
+-- == OTHER STRINGS FOR MENU == --
+-- -----------------------------------------------------------------------------------------------------------------
+-- PAIntegration Menu --
+SafeAddString(SI_PA_MENU_INTEGRATION_PAB_REQUIRED, "Требует включенного PABanking", 1)
+SafeAddString(SI_PA_MENU_INTEGRATION_PAJ_REQUIRED, "Требует включенного PAJunk", 1)
+
+SafeAddString(SI_PA_MENU_INTEGRATION_MORE_TO_COME, "Больше возможностей с FCO ItemSaver появятся в будущих версиях", 1)

--- a/PersonalAssistant/PersonalAssistantJunk/localization/ru.lua
+++ b/PersonalAssistant/PersonalAssistantJunk/localization/ru.lua
@@ -1,0 +1,146 @@
+local PAC = PersonalAssistant.Constants
+
+-- =================================================================================================================
+-- Language specific texts that need to be translated --
+
+-- =================================================================================================================
+-- == MENU/PANEL TEXTS == --
+-- -----------------------------------------------------------------------------------------------------------------
+-- PAJunk Menu --
+SafeAddString(SI_PA_MENU_JUNK_DESCRIPTION, "PAJunk может помечать предметы как хлам, если они соответствуют любому из выбираемых условий; кроме случаев, когда предмет был создан или получен по почте", 1)
+
+-- Standard Items --
+SafeAddString(SI_PA_MENU_JUNK_STANDARD_ITEMS_HEADER, "Обычные предметы", 1)
+SafeAddString(SI_PA_MENU_JUNK_AUTOMARK_ENABLE, "Включить пометку предметов как хлам", 1)
+
+SafeAddString(SI_PA_MENU_JUNK_TRASH_AUTOMARK, table.concat({"Помечать предметы типа [", GetString("SI_ITEMTYPE", ITEMTYPE_TRASH), "]"}), 1)
+SafeAddString(SI_PA_MENU_JUNK_TRASH_AUTOMARK_T, table.concat({"Автоматически помечать предметы типа [", GetString("SI_ITEMTYPE", ITEMTYPE_TRASH), "] как хлам."}), 1)
+SafeAddString(SI_PA_MENU_JUNK_TRASH_EXCLUDE_ITEMS_DESC, table.concat({"НЕ помечать [", GetString("SI_ITEMTYPE", ITEMTYPE_TRASH), "] как хлам если . . ."}), 1)
+SafeAddString(SI_PA_MENU_JUNK_TRASH_EXCLUDE_NIBBLES_AND_BITS, table.concat({"> он нужен для дейлика ", PAC.COLOR.YELLOW:Colorize("Nibbles and Bits")}), 1)
+SafeAddString(SI_PA_MENU_JUNK_TRASH_EXCLUDE_NIBBLES_AND_BITS_T, table.concat({PAC.COLOR.YELLOW:Colorize("Локация: "), PAC.COLOR.ORANGE:Colorize("Заводной город"), "\nЕсли включено - следующие предметы не будут помечаться как хлам:\n[Панцирь]\n[Грязная шкура]\n[Оболочка даэдра]"}), 1)
+SafeAddString(SI_PA_MENU_JUNK_TRASH_EXCLUDE_MORSELS_AND_PECKS, table.concat({"> он нужен для дейлика ", PAC.COLOR.YELLOW:Colorize("Morsels and Pecks")}), 1)
+SafeAddString(SI_PA_MENU_JUNK_TRASH_EXCLUDE_MORSELS_AND_PECKS_T, table.concat({PAC.COLOR.YELLOW:Colorize("Локация: "), PAC.COLOR.ORANGE:Colorize("Заводной город"), "\nЕсли включено - следующие предметы не будут помечаться как хлам:\n[Сущность элементаля]\n[Гибкие корни]\n[Эктоплазма]"}), 1)
+
+
+SafeAddString(SI_PA_MENU_JUNK_COLLECTIBLES_AUTOMARK, table.concat({"Помечать предметы типа [", GetString("SI_ITEMSELLINFORMATION", ITEM_SELL_INFORMATION_PRIORITY_SELL), "]"}), 1)
+SafeAddString(SI_PA_MENU_JUNK_COLLECTIBLES_AUTOMARK_T, table.concat({"Автоматически помечать предмет с типом [", GetString("SI_ITEMSELLINFORMATION", ITEM_SELL_INFORMATION_PRIORITY_SELL), "] как хлам."}), 1)
+
+SafeAddString(SI_PA_MENU_JUNK_TREASURES_AUTOMARK, table.concat({"Помечать предметы типа [", GetString("SI_ITEMTYPE", ITEMTYPE_TREASURE), "]"}), 1)
+SafeAddString(SI_PA_MENU_JUNK_TREASURES_AUTOMARK_T, table.concat({"Автоматически помечать предметы типа [", GetString("SI_ITEMTYPE", ITEMTYPE_TREASURE), "] как хлам."}), 1)
+SafeAddString(SI_PA_MENU_JUNK_TREASURES_EXCLUDE_ITEMS_DESC, table.concat({"НЕ помечать [", GetString("SI_ITEMTYPE", ITEMTYPE_TREASURE), "] как хлам если . . ."}), 1)
+SafeAddString(SI_PA_MENU_JUNK_TREASURES_EXCLUDE_A_MATTER_OF_LEISURE, table.concat({"> оно нужно для дейлика ", PAC.COLOR.YELLOW:Colorize("A Matter of Leisure")}), 1)
+SafeAddString(SI_PA_MENU_JUNK_TREASURES_EXCLUDE_A_MATTER_OF_LEISURE_T, table.concat({PAC.COLOR.YELLOW:Colorize("Локация: "), PAC.COLOR.ORANGE:Colorize("Заводной город"), "\nЕсли включено - следующие предметы не будут помечаться как хлам:\n[Детские игрушки]\n[Куклы]\n[Игры]"}), 1)
+SafeAddString(SI_PA_MENU_JUNK_TREASURES_EXCLUDE_A_MATTER_OF_RESPECT, table.concat({"> оно нужно для дейлика ", PAC.COLOR.YELLOW:Colorize("A Matter of Respect")}), 1)
+SafeAddString(SI_PA_MENU_JUNK_TREASURES_EXCLUDE_A_MATTER_OF_RESPECT_T, table.concat({PAC.COLOR.YELLOW:Colorize("Локация: "), PAC.COLOR.ORANGE:Colorize("Заводной город"), "\nЕсли включено - следующие предметы не будут помечаться как хлам:\n[Аксессуар]\n[Посуда]\n[Кухонные принадлежности]"}), 1)
+SafeAddString(SI_PA_MENU_JUNK_TREASURES_EXCLUDE_A_MATTER_OF_TRIBUTES, table.concat({"> оно нужно для дейлика ", PAC.COLOR.YELLOW:Colorize("A Matter of Tributes")}), 1)
+SafeAddString(SI_PA_MENU_JUNK_TREASURES_EXCLUDE_A_MATTER_OF_TRIBUTES_T, table.concat({PAC.COLOR.YELLOW:Colorize("Локация: "), PAC.COLOR.ORANGE:Colorize("Заводной город"), "\nЕсли включено - следующие предметы не будут помечаться как хлам:\n[Косметика]\n[Товары для ухода]"}), 1)
+
+-- Custom Items --
+SafeAddString(SI_PA_MENU_JUNK_CUSTOM_ITEMS_HEADER, "Настраиваемые предметы", 1)
+SafeAddString(SI_PA_MENU_JUNK_CUSTOM_ITEMS_DESCRIPTION, table.concat({GetString(SI_PA_MENU_RULES_HOW_TO_ADD_PAJ), "\n\n", GetString(SI_PA_MENU_RULES_HOW_TO_FIND_MENU)}), 1)
+
+-- Auto-Destroy --
+SafeAddString(SI_PA_MENU_JUNK_AUTO_DESTORY_JUNK_HEADER, "Автоматически уничтожать мусор", 1)
+SafeAddString(SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK, "Включить уничтожение ненужных предметов", 1)
+SafeAddString(SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_T, "При добыче бесполезного предмета (стоимость продажи - 0з) при включенном данном параметре - предмет будет уничтожен. Это не может быть отменено!", 1)
+SafeAddString(SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_W, "ВНИМАНИЕ: Обратите внимание, что при использовании этой настройки, никакого сообщения для подтверждения действия не будет!\nПросто будет уничтожен!\nНасовсем!\nИспользуйте на свой страх и риск!", 1)
+
+-- Other Settings --
+SafeAddString(SI_PA_MENU_JUNK_AUTOSELL_JUNK, "Продажа хлама у торговцев и скупщиков краденного", 1)
+
+SafeAddString(SI_PA_MENU_JUNK_KEYBINDINGS_HEADER, "Сочетания клавиш", 1)
+SafeAddString(SI_PA_MENU_JUNK_KEYBINDINGS_MARK_UNMARK_JUNK_ENABLE, "Включить сочетание \"Хлам/Не хлам\"", 1)
+SafeAddString(SI_PA_MENU_JUNK_KEYBINDINGS_MARK_UNMARK_JUNK_SHOW, "Показывать переключение \"Хлам/Не хлам\"", 1)
+SafeAddString(SI_PA_MENU_JUNK_KEYBINDINGS_DESTROY_ITEM_ENABLE, "Включить сочетание \"Уничтожить предмет\"", 1)
+SafeAddString(SI_PA_MENU_JUNK_KEYBINDINGS_DESTROY_ITEM_ENABLE_W, "ВНИМАНИЕ: Пожалуйста, имейте в виду, что при использовании этого сочетания клавиш НЕТ подтверждения, действительно ли вы хотите уничтожить предмет.\nОн просто будет уничтожен!\nНасовсем!\nИспользуйте на свой страх и риск!", 1)
+SafeAddString(SI_PA_MENU_JUNK_KEYBINDINGS_DESTROY_ITEM_SHOW, "Показывать переключение \"Уничтожить предмет\"", 1)
+SafeAddString(SI_PA_MENU_JUNK_KEYBINDINGS_EXCLUDE_DESCRIPTION, "Отключить сочетание \"Уничтожить предмет\" если он . . .", 1)
+SafeAddString(SI_PA_MENU_JUNK_KEYBINDINGS_DESTROY_QUALITY_THRESHOLD, "> по качеству выше или равен", 1)
+SafeAddString(SI_PA_MENU_JUNK_KEYBINDINGS_DESTROY_UNKNOWN, "> может быть изучен/исследован и неизвестен", 1)
+
+-- General texts used across: Weapons, Armor, Jewelry
+SafeAddString(SI_PA_MENU_JUNK_AUTOMARK_QUALITY_THRESHOLD, "Помечать экипировку такого качества и ниже", 1)
+SafeAddString(SI_PA_MENU_JUNK_AUTOMARK_QUALITY_THRESHOLD_T, "Автоматически помечать как хлам, если экипировка указанного качества или ниже", 1)
+SafeAddString(SI_PA_MENU_JUNK_AUTOMARK_ORNATE, table.concat({"Помечать экипировку с особенностью [", GetString("SI_ITEMTRAITTYPE", ITEM_TRAIT_TYPE_ARMOR_ORNATE), "]"}), 1)
+SafeAddString(SI_PA_MENU_JUNK_AUTOMARK_ORNATE_T, table.concat({"Автоматически помечать экипировку с особенностью [", GetString("SI_ITEMTRAITTYPE", ITEM_TRAIT_TYPE_ARMOR_ORNATE), "] (повышенная цена продажи) как хлам."}), 1)
+SafeAddString(SI_PA_MENU_JUNK_AUTOMARK_INCLUDE_SETS, "Помечать части сетов", 1)
+SafeAddString(SI_PA_MENU_JUNK_AUTOMARK_INCLUDE_SETS_T, "Если ВЫКЛЮЧЕНО, то только предметы не являющиеся частью сета могут быть помечены как хлам", 1)
+SafeAddString(SI_PA_MENU_JUNK_AUTOMARK_INCLUDE_INTRICATE, table.concat({"Помечать экипировку с особенностью [", GetString("SI_ITEMTRAITTYPE", ITEM_TRAIT_TYPE_ARMOR_INTRICATE),"]"}), 1)
+SafeAddString(SI_PA_MENU_JUNK_AUTOMARK_INCLUDE_INTRICATE_T, table.concat({"Если ВЫКЛЮЧЕНО, то экипировка с особенностью [", GetString("SI_ITEMTRAITTYPE", ITEM_TRAIT_TYPE_ARMOR_INTRICATE),"] не может быть помечена как хлам (независимо от качества)"}), 1)
+SafeAddString(SI_PA_MENU_JUNK_AUTOMARK_INCLUDE_UNKNOWN_TRAITS, "Помечать экипировку с неисследованной особенностью", 1)
+SafeAddString(SI_PA_MENU_JUNK_AUTOMARK_INCLUDE_UNKNOWN_TRAITS_T, "Если ВЫКЛЮЧЕНО, то только экипировка без особенности или с исследованной особенностью может быть помечена как хлам.", 1)
+
+
+-- =================================================================================================================
+-- == MAIN MENU TEXTS == --
+-- -----------------------------------------------------------------------------------------------------------------
+-- PAJunk --
+SafeAddString(SI_PA_MAINMENU_JUNK_HEADER, "Правила для хлама", 1)
+
+SafeAddString(SI_PA_MAINMENU_JUNK_HEADER_ITEM, "Предмет", 1)
+SafeAddString(SI_PA_MAINMENU_JUNK_HEADER_JUNK_COUNT, "Количество", 1)
+SafeAddString(SI_PA_MAINMENU_JUNK_HEADER_LAST_JUNK, "Последний раз", 1)
+SafeAddString(SI_PA_MAINMENU_JUNK_HEADER_RULE_ADDED, "Добавлено", 1)
+SafeAddString(SI_PA_MAINMENU_JUNK_HEADER_ACTIONS, "Действия", 1)
+
+SafeAddString(SI_PA_MAINMENU_JUNK_ROW_NEVER_JUNKED, "никогда", 1)
+
+
+-- =================================================================================================================
+-- == CHAT OUTPUTS == --
+-- -----------------------------------------------------------------------------------------------------------------
+-- PAJunk --
+SafeAddString(SI_PA_CHAT_JUNK_MARKED_AS_JUNK_TRASH, table.concat({"Отправили %s в хлам (", PAC.COLOR.ORANGE:Colorize(GetString("SI_ITEMTYPE", ITEMTYPE_TRASH)), ")"}), 1)
+SafeAddString(SI_PA_CHAT_JUNK_MARKED_AS_JUNK_ORNATE, table.concat({"Отправили %s в хлам (", PAC.COLOR.ORANGE:Colorize(GetString("SI_ITEMTRAITTYPE", ITEM_TRAIT_TYPE_ARMOR_ORNATE)), ")"}), 1)
+SafeAddString(SI_PA_CHAT_JUNK_MARKED_AS_JUNK_QUALITY, table.concat({"Отправили %s в хлам (", PAC.COLOR.ORANGE:Colorize("Качество"), ")"}), 1)
+SafeAddString(SI_PA_CHAT_JUNK_MARKED_AS_JUNK_MERCHANT, table.concat({"Отправили %s в хлам (", PAC.COLOR.ORANGE:Colorize("Продажа"), ")"}), 1)
+SafeAddString(SI_PA_CHAT_JUNK_MARKED_AS_JUNK_TREASURE, table.concat({"Отправили %s в хлам (", PAC.COLOR.ORANGE:Colorize("Сокровище"), ")"}), 1)
+SafeAddString(SI_PA_CHAT_JUNK_MARKED_AS_JUNK_KEYBINDING, table.concat({"Отправили %s в хлам (", PAC.COLOR.ORANGE:Colorize("Вручную"), ")"}), 1)
+SafeAddString(SI_PA_CHAT_JUNK_MARKED_AS_JUNK_PERMANENT, table.concat({"Отправили %s в хлам (", PAC.COLOR.ORANGE:Colorize("Постоянная пометка"), ")"}), 1)
+
+SafeAddString(SI_PA_CHAT_JUNK_DESTROYED_KEYBINDING, table.concat({PAC.COLOR.ORANGE_RED:Colorize("Уничтожен"), " %d x %s"}), 1)
+SafeAddString(SI_PA_CHAT_JUNK_DESTROYED_WORTHLESS, table.concat({PAC.COLOR.ORANGE_RED:Colorize("Уничтожен"), " %d x %s (", PAC.COLOR.ORANGE:Colorize("Мусор"), ")"}), 1)
+SafeAddString(SI_PA_CHAT_JUNK_DESTROY_WORTHLESS_ON, table.concat({"Автоматическое уничтожение мусора было ", PAC.COLOR.RED:Colorize("ВКЛЮЧЕНО")}), 1)
+SafeAddString(SI_PA_CHAT_JUNK_DESTROY_WORTHLESS_OFF, table.concat({"Автоматическое уничтожение мусора было ", PAC.COLOR.GREEN:Colorize("ВЫКЛЮЧЕНО")}), 1)
+
+SafeAddString(SI_PA_CHAT_JUNK_SOLD_ITEMS_INFO, "Продано предметов на %s", 1)
+SafeAddString(SI_PA_CHAT_JUNK_FENCE_LIMIT_HOURS, table.concat({GetString("SI_STOREFAILURE", STORE_FAILURE_AT_FENCE_LIMIT), " Пожалуйста, подождите ~%d часов"}), 1)
+SafeAddString(SI_PA_CHAT_JUNK_FENCE_LIMIT_MINUTES, table.concat({GetString("SI_STOREFAILURE", STORE_FAILURE_AT_FENCE_LIMIT), " Пожалуйста, подождите ~%d минут"}), 1)
+--    SafeAddString(SI_PA_CHAT_JUNK_FENCE_ITEM_WORTHLESS, table.concat({"Невозможно продать %s. ", GetString("SI_STOREFAILURE", STORE_FAILURE_WORTHLESS_TO_FENCE)}), 1)
+
+SafeAddString(SI_PA_CHAT_JUNK_RULES_ADDED, table.concat({"Предмет %s был ", PAC.COLOR.ORANGE:Colorize("добавлен"), " в настраиваемый список хлама!"}), 1)
+SafeAddString(SI_PA_CHAT_JUNK_RULES_DELETED, table.concat({"Предмет %s был ", PAC.COLOR.ORANGE:Colorize("удален"), " из настраиваемого списка хлама!"}), 1)
+
+-- =================================================================================================================
+-- == KEY BINDINGS == --
+-- -----------------------------------------------------------------------------------------------------------------
+-- PAJunk --
+SafeAddString(SI_BINDING_NAME_PA_JUNK_TOGGLE_ITEM, "Пометка Хлам/Не хлам", 1)
+SafeAddString(SI_BINDING_NAME_PA_JUNK_DESTROY_ITEM, "Уничтожить предмет", 1)
+
+
+-- =================================================================================================================
+-- == OTHER STRINGS == --
+-- -----------------------------------------------------------------------------------------------------------------
+-- Quest: "A Matter of Leisure"
+SafeAddString(SI_PA_TREASURE_ITEM_TAG_DESC_TOYS, "Детские игрушки", 1)
+SafeAddString(SI_PA_TREASURE_ITEM_TAG_DESC_DOLLS, "Куклы", 1)
+SafeAddString(SI_PA_TREASURE_ITEM_TAG_DESC_GAMES, "Игры", 1)
+
+-- Quest: "A Matter of Respect"
+SafeAddString(SI_PA_TREASURE_ITEM_TAG_DESC_UTENSILS, "Посуда", 1)
+SafeAddString(SI_PA_TREASURE_ITEM_TAG_DESC_DRINKWARE, "Питьевая посуда", 1)
+SafeAddString(SI_PA_TREASURE_ITEM_TAG_DESC_DISHES_COOKWARE, "Кухонная утварь", 1)
+
+-- Quest: "A Matter of Tributes"
+SafeAddString(SI_PA_TREASURE_ITEM_TAG_DESC_COSMETICS, "Косметика", 1)
+SafeAddString(SI_PA_TREASURE_ITEM_TAG_DESC_GROOMING, "Товары для ухода", 1)
+
+
+-- =================================================================================================================
+-- PAJunk Menu --
+-- Fix wrong endings of headers and fix unused collectibles translation
+SafeAddString(SI_PA_MENU_JUNK_COLLECTIBLES_HEADER, zo_strformat(GetString("SI_PA_ITEMTYPE", ITEMTYPE_COLLECTIBLE), 2), 1)
+SafeAddString(SI_PA_MENU_JUNK_WEAPONS_HEADER, zo_strformat(GetString("SI_ITEMFILTERTYPE", ITEMFILTERTYPE_WEAPONS), 2), 1)
+SafeAddString(SI_PA_MENU_JUNK_ARMOR_HEADER, zo_strformat(GetString("SI_ITEMFILTERTYPE", ITEMFILTERTYPE_ARMOR),2 ), 1)
+SafeAddString(SI_PA_MENU_JUNK_JEWELRY_HEADER, zo_strformat(GetString("SI_ITEMFILTERTYPE", ITEMFILTERTYPE_JEWELRY), 2), 1)

--- a/PersonalAssistant/PersonalAssistantJunk/localization/ru.lua
+++ b/PersonalAssistant/PersonalAssistantJunk/localization/ru.lua
@@ -101,7 +101,7 @@ SafeAddString(SI_PA_CHAT_JUNK_MARKED_AS_JUNK_STOLEN, table.concat({"Отправ
 SafeAddString(SI_PA_CHAT_JUNK_MARKED_AS_JUNK_PERMANENT, table.concat({"Отправили %s в хлам (", PAC.COLOR.ORANGE:Colorize("Постоянная пометка"), ")"}), 1)
 
 SafeAddString(SI_PA_CHAT_JUNK_DESTROYED_KEYBINDING, table.concat({PAC.COLOR.ORANGE_RED:Colorize("Уничтожен"), " %d x %s"}), 1)
-SafeAddString(SI_PA_CHAT_JUNK_DESTROYED_ALWAYS, table.concat({PAC.COLOR.ORANGE_RED:Colorize("Уничтожен"), " %d x %s (", PAC.COLOR.ORANGE:Colorize("Перманентно"), ")"}), 1)
+SafeAddString(SI_PA_CHAT_JUNK_DESTROYED_ALWAYS, table.concat({PAC.COLOR.ORANGE_RED:Colorize("Уничтожен"), " %d x %s (", PAC.COLOR.ORANGE:Colorize("Постоянная пометка"), ")"}), 1)
 SafeAddString(SI_PA_CHAT_JUNK_DESTROYED_WORTHLESS, table.concat({PAC.COLOR.ORANGE_RED:Colorize("Уничтожен"), " %d x %s (", PAC.COLOR.ORANGE:Colorize("Мусор"), ")"}), 1)
 SafeAddString(SI_PA_CHAT_JUNK_DESTROY_WORTHLESS_ON, table.concat({"Автоматическое уничтожение мусора было ", PAC.COLOR.RED:Colorize("ВКЛЮЧЕНО")}), 1)
 SafeAddString(SI_PA_CHAT_JUNK_DESTROY_WORTHLESS_OFF, table.concat({"Автоматическое уничтожение мусора было ", PAC.COLOR.GREEN:Colorize("ВЫКЛЮЧЕНО")}), 1)

--- a/PersonalAssistant/PersonalAssistantJunk/localization/ru.lua
+++ b/PersonalAssistant/PersonalAssistantJunk/localization/ru.lua
@@ -25,15 +25,16 @@ SafeAddString(SI_PA_MENU_JUNK_TRASH_EXCLUDE_MORSELS_AND_PECKS_T, table.concat({P
 SafeAddString(SI_PA_MENU_JUNK_COLLECTIBLES_AUTOMARK, table.concat({"Помечать предметы типа [", GetString("SI_ITEMSELLINFORMATION", ITEM_SELL_INFORMATION_PRIORITY_SELL), "]"}), 1)
 SafeAddString(SI_PA_MENU_JUNK_COLLECTIBLES_AUTOMARK_T, table.concat({"Автоматически помечать предмет с типом [", GetString("SI_ITEMSELLINFORMATION", ITEM_SELL_INFORMATION_PRIORITY_SELL), "] как хлам."}), 1)
 
-SafeAddString(SI_PA_MENU_JUNK_TREASURES_AUTOMARK, table.concat({"Помечать предметы типа [", GetString("SI_ITEMTYPE", ITEMTYPE_TREASURE), "]"}), 1)
-SafeAddString(SI_PA_MENU_JUNK_TREASURES_AUTOMARK_T, table.concat({"Автоматически помечать предметы типа [", GetString("SI_ITEMTYPE", ITEMTYPE_TREASURE), "] как хлам."}), 1)
-SafeAddString(SI_PA_MENU_JUNK_TREASURES_EXCLUDE_ITEMS_DESC, table.concat({"НЕ помечать [", GetString("SI_ITEMTYPE", ITEMTYPE_TREASURE), "] как хлам если . . ."}), 1)
-SafeAddString(SI_PA_MENU_JUNK_TREASURES_EXCLUDE_A_MATTER_OF_LEISURE, table.concat({"> оно нужно для дейлика ", PAC.COLOR.YELLOW:Colorize("A Matter of Leisure")}), 1)
-SafeAddString(SI_PA_MENU_JUNK_TREASURES_EXCLUDE_A_MATTER_OF_LEISURE_T, table.concat({PAC.COLOR.YELLOW:Colorize("Локация: "), PAC.COLOR.ORANGE:Colorize("Заводной город"), "\nЕсли включено - следующие предметы не будут помечаться как хлам:\n[Детские игрушки]\n[Куклы]\n[Игры]"}), 1)
-SafeAddString(SI_PA_MENU_JUNK_TREASURES_EXCLUDE_A_MATTER_OF_RESPECT, table.concat({"> оно нужно для дейлика ", PAC.COLOR.YELLOW:Colorize("A Matter of Respect")}), 1)
-SafeAddString(SI_PA_MENU_JUNK_TREASURES_EXCLUDE_A_MATTER_OF_RESPECT_T, table.concat({PAC.COLOR.YELLOW:Colorize("Локация: "), PAC.COLOR.ORANGE:Colorize("Заводной город"), "\nЕсли включено - следующие предметы не будут помечаться как хлам:\n[Аксессуар]\n[Посуда]\n[Кухонные принадлежности]"}), 1)
-SafeAddString(SI_PA_MENU_JUNK_TREASURES_EXCLUDE_A_MATTER_OF_TRIBUTES, table.concat({"> оно нужно для дейлика ", PAC.COLOR.YELLOW:Colorize("A Matter of Tributes")}), 1)
-SafeAddString(SI_PA_MENU_JUNK_TREASURES_EXCLUDE_A_MATTER_OF_TRIBUTES_T, table.concat({PAC.COLOR.YELLOW:Colorize("Локация: "), PAC.COLOR.ORANGE:Colorize("Заводной город"), "\nЕсли включено - следующие предметы не будут помечаться как хлам:\n[Косметика]\n[Товары для ухода]"}), 1)
+-- Stolen Items --
+SafeAddString(SI_PA_MENU_JUNK_AUTOMARK_STOLEN_HEADER, "Украденные вещи", 1)
+SafeAddString(SI_PA_MENU_JUNK_ACTION_STOLEN_PLACEHOLDER, "%s", 1)
+SafeAddString(SI_PA_MENU_JUNK_ACTION_STOLEN_TREASURES_EXCLUDE_ITEMS_DESC, table.concat({"НЕ уничтожать и НЕ помечать [", GetString("SI_ITEMTYPE", ITEMTYPE_TREASURE), "] как хлам если . . ."}), 1)
+SafeAddString(SI_PA_MENU_JUNK_ACTION_STOLEN_TREASURES_EXCLUDE_A_MATTER_OF_LEISURE, table.concat({"> оно нужно для дейлика ", PAC.COLOR.YELLOW:Colorize("A Matter of Leisure")}), 1)
+SafeAddString(SI_PA_MENU_JUNK_ACTION_STOLEN_TREASURES_EXCLUDE_A_MATTER_OF_LEISURE_T, table.concat({PAC.COLOR.YELLOW:Colorize("Локация: "), PAC.COLOR.ORANGE:Colorize("Заводной город"), "\nЕсли включено - следующие предметы не будут помечаться как хлам:\n[Детские игрушки]\n[Куклы]\n[Игры]"}), 1)
+SafeAddString(SI_PA_MENU_JUNK_ACTION_STOLEN_TREASURES_EXCLUDE_A_MATTER_OF_RESPECT, table.concat({"> оно нужно для дейлика ", PAC.COLOR.YELLOW:Colorize("A Matter of Respect")}), 1)
+SafeAddString(SI_PA_MENU_JUNK_ACTION_STOLEN_TREASURES_EXCLUDE_A_MATTER_OF_RESPECT_T, table.concat({PAC.COLOR.YELLOW:Colorize("Локация: "), PAC.COLOR.ORANGE:Colorize("Заводной город"), "\nЕсли включено - следующие предметы не будут помечаться как хлам:\n[Аксессуар]\n[Посуда]\n[Кухонные принадлежности]"}), 1)
+SafeAddString(SI_PA_MENU_JUNK_ACTION_STOLEN_TREASURES_EXCLUDE_A_MATTER_OF_TRIBUTES, table.concat({"> оно нужно для дейлика ", PAC.COLOR.YELLOW:Colorize("A Matter of Tributes")}), 1)
+SafeAddString(SI_PA_MENU_JUNK_ACTION_STOLEN_TREASURES_EXCLUDE_A_MATTER_OF_TRIBUTES_T, table.concat({PAC.COLOR.YELLOW:Colorize("Локация: "), PAC.COLOR.ORANGE:Colorize("Заводной город"), "\nЕсли включено - следующие предметы не будут помечаться как хлам:\n[Косметика]\n[Товары для ухода]"}), 1)
 
 -- Custom Items --
 SafeAddString(SI_PA_MENU_JUNK_CUSTOM_ITEMS_HEADER, "Настраиваемые предметы", 1)
@@ -95,10 +96,12 @@ SafeAddString(SI_PA_CHAT_JUNK_MARKED_AS_JUNK_ORNATE, table.concat({"Отправ
 SafeAddString(SI_PA_CHAT_JUNK_MARKED_AS_JUNK_QUALITY, table.concat({"Отправили %s в хлам (", PAC.COLOR.ORANGE:Colorize("Качество"), ")"}), 1)
 SafeAddString(SI_PA_CHAT_JUNK_MARKED_AS_JUNK_MERCHANT, table.concat({"Отправили %s в хлам (", PAC.COLOR.ORANGE:Colorize("Продажа"), ")"}), 1)
 SafeAddString(SI_PA_CHAT_JUNK_MARKED_AS_JUNK_TREASURE, table.concat({"Отправили %s в хлам (", PAC.COLOR.ORANGE:Colorize("Сокровище"), ")"}), 1)
-SafeAddString(SI_PA_CHAT_JUNK_MARKED_AS_JUNK_KEYBINDING, table.concat({"Отправили %s в хлам (", PAC.COLOR.ORANGE:Colorize("Вручную"), ")"}), 1)
+SafeAddString(SI_PA_CHAT_JUNK_MARKED_AS_JUNK_KEYBINDING, table.concat({"Отправили %s в хлам (", PAC.COLOR.ORANGE:Colorize("Ручное"), ")"}), 1)
+SafeAddString(SI_PA_CHAT_JUNK_MARKED_AS_JUNK_STOLEN, table.concat({"Отправили %s в хлам (", PAC.COLOR.ORANGE:Colorize("Краденое"), ")"}), 1)
 SafeAddString(SI_PA_CHAT_JUNK_MARKED_AS_JUNK_PERMANENT, table.concat({"Отправили %s в хлам (", PAC.COLOR.ORANGE:Colorize("Постоянная пометка"), ")"}), 1)
 
 SafeAddString(SI_PA_CHAT_JUNK_DESTROYED_KEYBINDING, table.concat({PAC.COLOR.ORANGE_RED:Colorize("Уничтожен"), " %d x %s"}), 1)
+SafeAddString(SI_PA_CHAT_JUNK_DESTROYED_ALWAYS, table.concat({PAC.COLOR.ORANGE_RED:Colorize("Уничтожен"), " %d x %s (", PAC.COLOR.ORANGE:Colorize("Перманентно"), ")"}), 1)
 SafeAddString(SI_PA_CHAT_JUNK_DESTROYED_WORTHLESS, table.concat({PAC.COLOR.ORANGE_RED:Colorize("Уничтожен"), " %d x %s (", PAC.COLOR.ORANGE:Colorize("Мусор"), ")"}), 1)
 SafeAddString(SI_PA_CHAT_JUNK_DESTROY_WORTHLESS_ON, table.concat({"Автоматическое уничтожение мусора было ", PAC.COLOR.RED:Colorize("ВКЛЮЧЕНО")}), 1)
 SafeAddString(SI_PA_CHAT_JUNK_DESTROY_WORTHLESS_OFF, table.concat({"Автоматическое уничтожение мусора было ", PAC.COLOR.GREEN:Colorize("ВЫКЛЮЧЕНО")}), 1)
@@ -106,7 +109,8 @@ SafeAddString(SI_PA_CHAT_JUNK_DESTROY_WORTHLESS_OFF, table.concat({"Автома
 SafeAddString(SI_PA_CHAT_JUNK_SOLD_ITEMS_INFO, "Продано предметов на %s", 1)
 SafeAddString(SI_PA_CHAT_JUNK_FENCE_LIMIT_HOURS, table.concat({GetString("SI_STOREFAILURE", STORE_FAILURE_AT_FENCE_LIMIT), " Пожалуйста, подождите ~%d часов"}), 1)
 SafeAddString(SI_PA_CHAT_JUNK_FENCE_LIMIT_MINUTES, table.concat({GetString("SI_STOREFAILURE", STORE_FAILURE_AT_FENCE_LIMIT), " Пожалуйста, подождите ~%d минут"}), 1)
---    SafeAddString(SI_PA_CHAT_JUNK_FENCE_ITEM_WORTHLESS, table.concat({"Невозможно продать %s. ", GetString("SI_STOREFAILURE", STORE_FAILURE_WORTHLESS_TO_FENCE)}), 1)
+SafeAddString(SI_PA_CHAT_JUNK_FENCE_ITEM_WORTHLESS, table.concat({"Невозможно продать %s. ", GetString("SI_STOREFAILURE", STORE_FAILURE_WORTHLESS_TO_FENCE)}), 1)
+SafeAddString(SI_PA_CHAT_JUNK_CANNOT_SELL_ITEM, "Невозможно продать %s", 1)
 
 SafeAddString(SI_PA_CHAT_JUNK_RULES_ADDED, table.concat({"Предмет %s был ", PAC.COLOR.ORANGE:Colorize("добавлен"), " в настраиваемый список хлама!"}), 1)
 SafeAddString(SI_PA_CHAT_JUNK_RULES_DELETED, table.concat({"Предмет %s был ", PAC.COLOR.ORANGE:Colorize("удален"), " из настраиваемого списка хлама!"}), 1)
@@ -141,6 +145,6 @@ SafeAddString(SI_PA_TREASURE_ITEM_TAG_DESC_GROOMING, "Товары для ухо
 -- PAJunk Menu --
 -- Fix wrong endings of headers and fix unused collectibles translation
 SafeAddString(SI_PA_MENU_JUNK_COLLECTIBLES_HEADER, zo_strformat(GetString("SI_PA_ITEMTYPE", ITEMTYPE_COLLECTIBLE), 2), 1)
-SafeAddString(SI_PA_MENU_JUNK_WEAPONS_HEADER, zo_strformat(GetString("SI_ITEMFILTERTYPE", ITEMFILTERTYPE_WEAPONS), 2), 1)
-SafeAddString(SI_PA_MENU_JUNK_ARMOR_HEADER, zo_strformat(GetString("SI_ITEMFILTERTYPE", ITEMFILTERTYPE_ARMOR),2 ), 1)
-SafeAddString(SI_PA_MENU_JUNK_JEWELRY_HEADER, zo_strformat(GetString("SI_ITEMFILTERTYPE", ITEMFILTERTYPE_JEWELRY), 2), 1)
+SafeAddString(SI_PA_MENU_JUNK_WEAPONS_HEADER, zo_strformat(GetString("SI_ITEMFILTERTYPE", ITEMFILTERTYPE_WEAPONS), 1), 1)
+SafeAddString(SI_PA_MENU_JUNK_ARMOR_HEADER, zo_strformat(GetString("SI_ITEMFILTERTYPE", ITEMFILTERTYPE_ARMOR),1 ), 1)
+SafeAddString(SI_PA_MENU_JUNK_JEWELRY_HEADER, zo_strformat(GetString("SI_ITEMFILTERTYPE", ITEMFILTERTYPE_JEWELRY), 1), 1)

--- a/PersonalAssistant/PersonalAssistantLoot/localization/ru.lua
+++ b/PersonalAssistant/PersonalAssistantLoot/localization/ru.lua
@@ -1,0 +1,88 @@
+local PAC = PersonalAssistant.Constants
+
+-- =================================================================================================================
+-- Language specific texts that need to be translated --
+
+-- =================================================================================================================
+-- == MENU/PANEL TEXTS == --
+-- -----------------------------------------------------------------------------------------------------------------
+SafeAddString(SI_PA_MENU_LOOT_DESCRIPTION, "PALoot информирует вас об предметах особого интереса таких как неизвестные рецепты, мотивы или особенности", 1)
+
+-- PALoot Loot Events --
+SafeAddString(SI_PA_MENU_LOOT_EVENTS_HEADER, "Добыча", 1)
+SafeAddString(SI_PA_MENU_LOOT_EVENTS_ENABLE, "Включить отслеживание добычи", 1)
+
+-- Loot Recipes
+SafeAddString(SI_PA_MENU_LOOT_RECIPES_HEADER, table.concat({"Когда добываются ", zo_strformat(GetString("SI_PA_ITEMTYPE", ITEMTYPE_RECIPE), 2)}), 1)
+SafeAddString(SI_PA_MENU_LOOT_RECIPES_UNKNOWN_MSG, table.concat({"> ", GetString("SI_ITEMTYPE", ITEMTYPE_RECIPE), " неизвестен"}), 1)
+SafeAddString(SI_PA_MENU_LOOT_RECIPES_UNKNOWN_MSG_T, table.concat({"Всякий раз, когда добывается ", GetString("SI_ITEMTYPE", ITEMTYPE_RECIPE), " который этот персонаж еще не изучил, в чате отображается сообщение"}), 1)
+
+-- Loot Motifs & Style Pages
+SafeAddString(SI_PA_MENU_LOOT_STYLES_HEADER, "Когда добываются стили", 1)
+SafeAddString(SI_PA_MENU_LOOT_MOTIFS_UNKNOWN_MSG, table.concat({"> ", GetString("SI_ITEMTYPE", ITEMTYPE_RACIAL_STYLE_MOTIF), " неизвестен"}), 1)
+SafeAddString(SI_PA_MENU_LOOT_MOTIFS_UNKNOWN_MSG_T, table.concat({"Всякий раз, когда добывается ", GetString("SI_ITEMTYPE", ITEMTYPE_RACIAL_STYLE_MOTIF), " который этот персонаж еще не изучил, в чате отображается сообщение"}), 1)
+SafeAddString(SI_PA_MENU_LOOT_STYLEPAGES_UNKNOWN_MSG, table.concat({"> ", GetString("SI_SPECIALIZEDITEMTYPE", SPECIALIZED_ITEMTYPE_CONTAINER_STYLE_PAGE), " неизвестен"}), 1)
+SafeAddString(SI_PA_MENU_LOOT_STYLEPAGES_UNKNOWN_MSG_T, table.concat({"Всякий раз, когда добывается ", GetString("SI_SPECIALIZEDITEMTYPE", SPECIALIZED_ITEMTYPE_CONTAINER_STYLE_PAGE), " который этот персонаж еще не изучил, в чате отображается сообщение"}), 1)
+
+-- Loot Equipment (Apparel, Weapons & Jewelries)
+SafeAddString(SI_PA_MENU_LOOT_APPARELWEAPONS_HEADER, "Когда добывается экипировка", 1)
+SafeAddString(SI_PA_MENU_LOOT_APPARELWEAPONS_UNKNOWN_MSG, "> Особенность еще не исследована", 1)
+SafeAddString(SI_PA_MENU_LOOT_APPARELWEAPONS_UNKNOWN_MSG_T, table.concat({"Всякий раз, когда добывается ", GetString("SI_ITEMFILTERTYPE", ITEMFILTERTYPE_ARMOR), ", a ", GetString("SI_ITEMFILTERTYPE", ITEMFILTERTYPE_WEAPONS), ", or ", GetString("SI_ITEMFILTERTYPE", ITEMFILTERTYPE_JEWELRY), " с особенностью которую этот персонаж еще не исследовал, в чате отображается сообщение"}), 1)
+
+SafeAddString(SI_PA_MENU_LOOT_LOW_INVENTORY_WARNING, "Предупреждать, когда мало места в инвентаре", 1)
+SafeAddString(SI_PA_MENU_LOOT_LOW_INVENTORY_WARNING_T, "Отображать предупреждение в окне чата, если у вас мало места в инвентаре", 1)
+SafeAddString(SI_PA_MENU_LOOT_LOW_INVENTORY_THRESHOLD, "Порог свободного места", 1)
+SafeAddString(SI_PA_MENU_LOOT_LOW_INVENTORY_THRESHOLD_T, "Если оставшееся свободное место в инвентаре находится на этом пороге или ниже, в окне чата отображается сообщение", 1)
+
+-- PALoot Mark Items --
+SafeAddString(SI_PA_MENU_LOOT_ICONS_HEADER, "Пометка предметов", 1)
+SafeAddString(SI_PA_MENU_LOOT_ICONS_ENABLE, "Включить дополнительные метки", 1)
+SafeAddString(SI_PA_MENU_LOOT_ICONS_ANY_SHOW_TOOLTIP, "Показывать подсказки у меток", 1)
+
+-- Mark Recipes --
+SafeAddString(SI_PA_MENU_LOOT_ICONS_RECIPES_HEADER, table.concat({"Отмечать ", zo_strformat(GetString("SI_PA_ITEMTYPE", ITEMTYPE_RECIPE), 2)}), 1)
+SafeAddString(SI_PA_MENU_LOOT_ICONS_RECIPE_SHOW_KNOWN, table.concat({">", PAC.ICONS.OTHERS.KNOWN.NORMAL, "если ", GetString("SI_ITEMTYPE", ITEMTYPE_RECIPE), " уже известен"}), 1)
+SafeAddString(SI_PA_MENU_LOOT_ICONS_RECIPE_SHOW_UNKNOWN, table.concat({">", PAC.ICONS.OTHERS.UNKNOWN.NORMAL, "если ", GetString("SI_ITEMTYPE", ITEMTYPE_RECIPE), " еще неизвестен"}), 1)
+
+-- Mark Motifs and Style Page Containers --
+SafeAddString(SI_PA_MENU_LOOT_ICONS_STYLES_HEADER, "Пометка стилей", 1)
+SafeAddString(SI_PA_MENU_LOOT_ICONS_MOTIFS_SHOW_KNOWN, table.concat({">", PAC.ICONS.OTHERS.KNOWN.NORMAL, "если ", GetString("SI_ITEMTYPE", ITEMTYPE_RACIAL_STYLE_MOTIF), " уже известен"}), 1)
+SafeAddString(SI_PA_MENU_LOOT_ICONS_MOTIFS_SHOW_UNKNOWN, table.concat({">", PAC.ICONS.OTHERS.UNKNOWN.NORMAL, "если ", GetString("SI_ITEMTYPE", ITEMTYPE_RACIAL_STYLE_MOTIF), " еще неизвестен"}), 1)
+SafeAddString(SI_PA_MENU_LOOT_ICONS_STYLEPAGES_SHOW_KNOWN, table.concat({">", PAC.ICONS.OTHERS.KNOWN.NORMAL, "если ", GetString("SI_SPECIALIZEDITEMTYPE", SPECIALIZED_ITEMTYPE_CONTAINER_STYLE_PAGE), " уже известен"}), 1)
+SafeAddString(SI_PA_MENU_LOOT_ICONS_STYLEPAGES_SHOW_UNKNOWN, table.concat({">", PAC.ICONS.OTHERS.UNKNOWN.NORMAL, "если ", GetString("SI_SPECIALIZEDITEMTYPE", SPECIALIZED_ITEMTYPE_CONTAINER_STYLE_PAGE), " еще неизвестен"}), 1)
+
+-- Mark Equipment (Apparel, Weapons & Jewelries) --
+SafeAddString(SI_PA_MENU_LOOT_ICONS_APPARELWEAPONS_HEADER, "Пометка экипировки", 1)
+SafeAddString(SI_PA_MENU_LOOT_ICONS_APPARELWEAPONS_SHOW_KNOWN, table.concat({">", PAC.ICONS.OTHERS.KNOWN.NORMAL, "если Особенность уже изучена"}), 1)
+SafeAddString(SI_PA_MENU_LOOT_ICONS_APPARELWEAPONS_SHOW_UNKNOWN, table.concat({">", PAC.ICONS.OTHERS.UNKNOWN.NORMAL, "если Особенность еще не изучена"}), 1)
+
+SafeAddString(SI_PA_MENU_LOOT_ICONS_SIZE_LIST, "Размер иконки (В виде списка)", 1)
+SafeAddString(SI_PA_MENU_LOOT_ICONS_SIZE_LIST_T, "Задает размер известных/неизвестных значков там, где предметы отображаются в виде списка", 1)
+SafeAddString(SI_PA_MENU_LOOT_ICONS_SIZE_GRID, "Размер иконки (В виде сетки)", 1)
+SafeAddString(SI_PA_MENU_LOOT_ICONS_SIZE_GRID_T, "Задает размер известных/неизвестных значков там, где предметы отображаются аддоном в виде сетки [InventoryGridView]", 1)
+
+SafeAddString(SI_PA_MENU_LOOT_ICONS_POSITION, "Положение иконки", 1)
+SafeAddString(SI_PA_MENU_LOOT_ICONS_POSITION_T, "Задает положение известных/неизвестных значков.\nPALoot «автоматически» определяет, включены ли дополнения [Research Assistant] или [ESO Master Recipe List], и помещает значок в еще не занятый угол", 1)
+
+
+-- =================================================================================================================
+-- == CHAT OUTPUTS == --
+-- -----------------------------------------------------------------------------------------------------------------
+-- PALoot --
+SafeAddString(SI_PA_CHAT_LOOT_RECIPE_UNKNOWN, table.concat({PAC.ICONS.OTHERS.UNKNOWN.SMALL, "%s может быть ", PAC.COLORS.ORANGE,"изучен", PAC.COLORS.DEFAULT, "!"}), 1)
+SafeAddString(SI_PA_CHAT_LOOT_MOTIF_UNKNOWN, table.concat({PAC.ICONS.OTHERS.UNKNOWN.SMALL, "%s может быть ", PAC.COLORS.ORANGE,"изучен", PAC.COLORS.DEFAULT, "!"}), 1)
+SafeAddString(SI_PA_CHAT_LOOT_TRAIT_UNKNOWN, table.concat({PAC.ICONS.OTHERS.UNKNOWN.SMALL, "%s с особенностью [", PAC.COLORS.ORANGE,"%s", PAC.COLORS.DEFAULT,"] можно исследовать!"}), 1)
+
+SafeAddString(SI_PA_PATTERN_INVENTORY_COUNT, table.concat({"%sУ вас <<1[", PAC.COLORS.WHITE,"нет/осталось ", PAC.COLORS.WHITE, "%d/осталось ", PAC.COLORS.WHITE, "%d]>> %s<<1[свободных мест/свободное место/свободных мест]>>!"}), 1)
+SafeAddString(SI_PA_PATTERN_REPAIRKIT_COUNT, table.concat({"%sУ вас <<1[", PAC.COLORS.WHITE,"нет/остался ", PAC.COLORS.WHITE, "%d/осталось ", PAC.COLORS.WHITE, "%d]>> %s<<1[Ремонтных наборов/Ремонтный набор/Ремонтных наборов]>> left!"}), 1)
+SafeAddString(SI_PA_PATTERN_SOULGEM_COUNT, table.concat({"%sУ вас <<1[", PAC.COLORS.WHITE,"нет/остался ", PAC.COLORS.WHITE, "%d/осталось ", PAC.COLORS.WHITE, "%d]>> %s<<1[Камней душ/Камень душ/Камней душ]>> left!"}), 1)
+
+
+-- =================================================================================================================
+-- == OTHER STRINGS FOR MENU == --
+-- -----------------------------------------------------------------------------------------------------------------
+-- PALoot --
+SafeAddString(SI_PA_DISPLAY_A_MESSAGE_WHEN, "Вывести сообщение, если . . .", 1)
+SafeAddString(SI_PA_MARK_WITH, "Помечать . . .", 1)
+SafeAddString(SI_PA_ITEM_KNOWN, "Известен", 1)
+SafeAddString(SI_PA_ITEM_UNKNOWN, "Неизвестен", 1)

--- a/PersonalAssistant/PersonalAssistantRepair/localization/ru.lua
+++ b/PersonalAssistant/PersonalAssistantRepair/localization/ru.lua
@@ -1,0 +1,65 @@
+local PAC = PersonalAssistant.Constants
+-- =================================================================================================================
+-- Language specific texts that need to be translated --
+
+-- =================================================================================================================
+-- == MENU/PANEL TEXTS == --
+-- -----------------------------------------------------------------------------------------------------------------
+-- PARepair Menu --
+SafeAddString(SI_PA_MENU_REPAIR_DESCRIPTION, "PARepair ремонтирует ваши доспехи и перезаряжает оружие за вас, будь то у торговца или в полевых условиях", 1)
+
+-- Equipped Items --
+SafeAddString(SI_PA_MENU_REPAIR_EQUIPPED_HEADER, "Экипированные предметы", 1)
+SafeAddString(SI_PA_MENU_REPAIR_ENABLE, "Включить восстановление экипировки", 1)
+
+SafeAddString(SI_PA_MENU_REPAIR_GOLD_HEADER, table.concat({"Ремонт за ", GetCurrencyName(CURT_MONEY)}), 1)
+SafeAddString(SI_PA_MENU_REPAIR_GOLD_ENABLE, table.concat({"Ремонтировать за ", GetCurrencyName(CURT_MONEY)}), 1)
+SafeAddString(SI_PA_MENU_REPAIR_GOLD_ENABLE_T, "Все экипированные предметы с прочностью ниже или равной указанной будут автоматически отремонтированы при посещении торговца", 1)
+SafeAddString(SI_PA_MENU_REPAIR_GOLD_DURABILITY, "Порог прочности %", 1)
+SafeAddString(SI_PA_MENU_REPAIR_GOLD_DURABILITY_T, "Экипированные предметы ремонтируются только если их прочность ниже или равна указанной", 1)
+
+SafeAddString(SI_PA_MENU_REPAIR_REPAIRKIT_HEADER, table.concat({"Ремонт за ", GetString(SI_PA_MENU_BANKING_REPAIRKIT)}), 1)
+SafeAddString(SI_PA_MENU_REPAIR_REPAIRKIT_ENABLE, table.concat({"Использовать ", GetString(SI_PA_MENU_BANKING_REPAIRKIT)}), 1)
+SafeAddString(SI_PA_MENU_REPAIR_REPAIRKIT_ENABLE_T, "Все предметы с прочностью ниже или равной указанной будут автоматически отремонтированы в полевых условиях", 1)
+SafeAddString(SI_PA_MENU_REPAIR_REPAIRKIT_DURABILITY, "Порог прочности %", 1)
+SafeAddString(SI_PA_MENU_REPAIR_REPAIRKIT_DURABILITY_T, "Предметы ремонтируются только если их прочность ниже или равна указанной", 1)
+--    SafeAddString(SI_PA_MENU_REPAIR_REPAIRKIT_CROWN_ENABLE, table.concat({"Использовать кронные наборы ", GetString(SI_PA_MENU_BANKING_REPAIRKIT)}), 1)
+--    SafeAddString(SI_PA_MENU_REPAIR_REPAIRKIT_CROWN_ENABLE_T, "???", 1)
+--    SafeAddString(SI_PA_MENU_REPAIR_REPAIRKIT_CROWN_DURABILITY, "Средняя прочность %", 1)
+--    SafeAddString(SI_PA_MENU_REPAIR_REPAIRKIT_CROWN_DURABILITY_T, "Вся экипировка ремонтируются только если её средняя прочность ниже или равна указанной", 1)
+SafeAddString(SI_PA_MENU_REPAIR_REPAIRKIT_LOW_KIT_WARNING, table.concat({"Сообщать что заканчиваются ", GetString(SI_PA_MENU_BANKING_REPAIRKIT)}), 1)
+SafeAddString(SI_PA_MENU_REPAIR_REPAIRKIT_LOW_KIT_WARNING_T, table.concat({"Сообщать в чат что заканчиваются ", GetString(SI_PA_MENU_BANKING_REPAIRKIT), ". Если количество упало до нуля, предупреждать раз в 10 минут."}), 1)
+SafeAddString(SI_PA_MENU_REPAIR_REPAIRKIT_LOW_KIT_THRESHOLD, "Порог количества", 1)
+SafeAddString(SI_PA_MENU_REPAIR_REPAIRKIT_LOW_KIT_THRESHOLD_T, table.concat({"Если ", GetString(SI_PA_MENU_BANKING_REPAIRKIT), " упали менее данного порога, сообщение об этом будет показано в окне чата"}), 1)
+
+SafeAddString(SI_PA_MENU_REPAIR_RECHARGE_HEADER, table.concat({"Заряжать оружие за ", zo_strformat(GetString("SI_PA_ITEMTYPE", ITEMTYPE_SOUL_GEM), 2)}), 1)
+SafeAddString(SI_PA_MENU_REPAIR_RECHARGE_ENABLE, table.concat({"Использовать ", zo_strformat(GetString("SI_PA_ITEMTYPE", ITEMTYPE_SOUL_GEM), 2)}), 1)
+SafeAddString(SI_PA_MENU_REPAIR_RECHARGE_ENABLE_T, "Заряжать экипированное оружие, когда уровень его зарядки достигает нуля. Сначала будут использоваться кронные камни душ и только потом обычные.", 1)
+--    SafeAddString(SI_PA_MENU_REPAIR_RECHARGE_CHATMODE, "Сообщение чата после зарядки", 1)
+--    SafeAddString(SI_PA_MENU_REPAIR_RECHARGE_CHATMODE_T, "Что показывать после зарядки экипированного оружия в окне чата", 1)
+SafeAddString(SI_PA_MENU_REPAIR_RECHARGE_LOW_GEM_WARNING, table.concat({"Сообщать что заканчиваются ", zo_strformat(GetString("SI_PA_ITEMTYPE", ITEMTYPE_SOUL_GEM), 2)}), 1)
+SafeAddString(SI_PA_MENU_REPAIR_RECHARGE_LOW_GEM_WARNING_T, table.concat({"Сообщать в чат, что заканчиваются ", zo_strformat(GetString("SI_PA_ITEMTYPE", ITEMTYPE_SOUL_GEM), 2), ". Если количество упало до нуля, предупреждать раз в 10 минут."}), 1)
+SafeAddString(SI_PA_MENU_REPAIR_RECHARGE_LOW_GEM_THRESHOLD, "Порог количества", 1)
+SafeAddString(SI_PA_MENU_REPAIR_RECHARGE_LOW_GEM_THRESHOLD_T, table.concat({"Если ", zo_strformat(GetString("SI_PA_ITEMTYPE", ITEMTYPE_SOUL_GEM), 2), " упали менее данного порога, сообщение об этом будет показано в окне чата"}), 1)
+
+-- Inventory Items --
+SafeAddString(SI_PA_MENU_REPAIR_INVENTORY_HEADER, "Предметы в инвентаре", 1)
+SafeAddString(SI_PA_MENU_REPAIR_INVENTORY_ENABLE, "Ремонтировать предметы в инвентаре", 1)
+
+SafeAddString(SI_PA_MENU_REPAIR_GOLD_INVENTORY_ENABLE, table.concat({"Ремонтировать за ", GetCurrencyName(CURT_MONEY)}), 1)
+SafeAddString(SI_PA_MENU_REPAIR_GOLD_INVENTORY_ENABLE_T, "Все предметы в инвентаре с прочностью ниже или равной указанной будут автоматически отремонтированы при посещении торговца", 1)
+SafeAddString(SI_PA_MENU_REPAIR_GOLD_INVENTORY_DURABILITY, "Порог прочности %", 1)
+SafeAddString(SI_PA_MENU_REPAIR_GOLD_INVENTORY_DURABILITY_T, "Предметы в инвентаре ремонтируются только если их прочность ниже или равна указанной", 1)
+
+
+-- =================================================================================================================
+-- == CHAT OUTPUTS == --
+-- -----------------------------------------------------------------------------------------------------------------
+-- PARepair --
+SafeAddString(SI_PA_CHAT_REPAIR_SUMMARY_FULL, "Восстановлено экипированное за %s", 1)
+SafeAddString(SI_PA_CHAT_REPAIR_SUMMARY_PARTIAL, "Восстановлено экипированное за %s (%s не хватило)", 1)
+
+SafeAddString(SI_PA_CHAT_REPAIR_SUMMARY_INVENTORY_FULL, "Восстановлено в инвентаре за %s", 1)
+SafeAddString(SI_PA_CHAT_REPAIR_SUMMARY_INVENTORY_PARTIAL, "Восстановлено в инвентаре за %s (%s не хватило)", 1)
+
+SafeAddString(SI_PA_CHAT_REPAIR_REPAIRKIT_REPAIRED, table.concat({"Восстановлено %s ", PAC.COLORS.WHITE, "(%d%%)", PAC.COLORS.DEFAULT, " за %s"}), 1)

--- a/PersonalAssistant/localization/de.lua
+++ b/PersonalAssistant/localization/de.lua
@@ -98,6 +98,7 @@ SafeAddString(SI_PA_BANKING_MOVE_MODE_DONOTHING, "Nichts machen", 1)
 SafeAddString(SI_PA_BANKING_MOVE_MODE_TOBANK, "In Truhe einlagern", 1)
 SafeAddString(SI_PA_BANKING_MOVE_MODE_TOBACKPACK, "Ins Inventar entnehmen", 1)
 
+SafeAddString(SI_PA_MENU_BANKING_ADVANCED_GLYPHS, "Glyphen", 1)
 SafeAddString(SI_PA_MENU_BANKING_ADVANCED_INTRICATE_ITEMS, "Intrikate Gegenstände", 1)
 
 SafeAddString(SI_PA_MENU_BANKING_REPAIRKIT, "Reparaturmaterialien", 1)

--- a/PersonalAssistant/localization/en.lua
+++ b/PersonalAssistant/localization/en.lua
@@ -99,6 +99,7 @@ local PAStrings = {
     SI_PA_BANKING_MOVE_MODE_TOBANK = "Deposit to Bank",
     SI_PA_BANKING_MOVE_MODE_TOBACKPACK = "Withdraw to Backpack",
 
+    SI_PA_MENU_BANKING_ADVANCED_GLYPHS = "Glyphs",
     SI_PA_MENU_BANKING_ADVANCED_INTRICATE_ITEMS = "Intricate Items",
 
     SI_PA_MENU_BANKING_REPAIRKIT = "Repair Kits",

--- a/PersonalAssistant/localization/fr.lua
+++ b/PersonalAssistant/localization/fr.lua
@@ -97,6 +97,7 @@ SafeAddString(SI_PA_BANKING_MOVE_MODE_DONOTHING, "Ne rien faire", 1)
 SafeAddString(SI_PA_BANKING_MOVE_MODE_TOBANK, "Déposer en banque", 1)
 SafeAddString(SI_PA_BANKING_MOVE_MODE_TOBACKPACK, "Prendre dans le sac", 1)
 
+SafeAddString(SI_PA_MENU_BANKING_ADVANCED_GLYPHS, "Glyphes", 1)
 SafeAddString(SI_PA_MENU_BANKING_ADVANCED_INTRICATE_ITEMS, "Objets complexes", 1)
 
 SafeAddString(SI_PA_MENU_BANKING_REPAIRKIT, "Nécessaires de réparation", 1)

--- a/PersonalAssistant/localization/ru.lua
+++ b/PersonalAssistant/localization/ru.lua
@@ -72,13 +72,16 @@ SafeAddString(SI_PA_ITEMTYPE4, "<<1[Еда/Еда]>>", 1) -- ITEMTYPE_FOOD
 SafeAddString(SI_PA_ITEMTYPE5, "<<1[Трофей/Трофеи]>>", 1) -- ITEMTYPE_TROPHY
 SafeAddString(SI_PA_ITEMTYPE7, "<<1[Зелье/Зелья]>>", 1) -- ITEMTYPE_POTION
 SafeAddString(SI_PA_ITEMTYPE8, "<<1[Мотив/Мотивы]>>", 1) -- ITEMTYPE_RACIAL_STYLE_MOTIF
+SafeAddString(SI_PA_ITEMTYPE10, "<<1[Ингридиент/Ингредиенты]>>", 1) -- ITEMTYPE_INGREDIENT
 SafeAddString(SI_PA_ITEMTYPE12, "<<1[Напиток/Напитки]>>", 1) -- ITEMTYPE_DRINK
+SafeAddString(SI_PA_ITEMTYPE16, "<<1[Наживка/Наживка]>>", 1) -- ITEMTYPE_LURE
 SafeAddString(SI_PA_ITEMTYPE22, "<<1[Отмычка/Отмычки]>>", 1) -- todo: unused
 SafeAddString(SI_PA_ITEMTYPE19, "<<1[Камень душ/Камни душ]>>", 1) -- ITEMTYPE_SOUL_GEM
 SafeAddString(SI_PA_ITEMTYPE29, "<<1[Рецепт/Рецепты]>>", 1) -- ITEMTYPE_RECIPE
 SafeAddString(SI_PA_ITEMTYPE30, "<<1[Яд/Яды]>>", 1) -- ITEMTYPE_POISON
 SafeAddString(SI_PA_ITEMTYPE34, "<<1[Коллекционный предмет/Коллекционные предметы]>>", 1) -- ITEMTYPE_COLLECTIBLE
 SafeAddString(SI_PA_ITEMTYPE47, "<<1[Ремонтный набор войны альянсов/Ремонтные наборы войны альянсов]>>", 1) -- todo: unused
+SafeAddString(SI_PA_ITEMTYPE56, "<<1[Сокровище/Сокровища]>>", 1) -- ITEMTYPE_TREASURE
 SafeAddString(SI_PA_ITEMTYPE60, "<<1[Мастерский заказ/Мастерские заказы]>>", 1) -- ITEMTYPE_MASTER_WRIT
 
 -- -----------------------------------------------------------------------------------------------------------------
@@ -142,6 +145,14 @@ SafeAddString(SI_PA_POSITION_TOPLEFT, "Вверху слева", 1)
 SafeAddString(SI_PA_POSITION_TOPRIGHT, "Вверху справа", 1)
 SafeAddString(SI_PA_POSITION_BOTTOMLEFT, "Внизу слева", 1)
 SafeAddString(SI_PA_POSITION_BOTTOMRIGHT, "Внизу справа", 1)
+
+-- -----------------------------------------------------------------------------------------------------------------
+-- PAJunk --
+SafeAddString(SI_PA_ITEM_ACTION_NOTHING, "Ничего не делать", 1)
+SafeAddString(SI_PA_ITEM_ACTION_LAUNDER, "Отмывать у скупщика", 1) -- not used so far
+SafeAddString(SI_PA_ITEM_ACTION_MARK_AS_JUNK, "Пометить как хлам", 1)
+SafeAddString(SI_PA_ITEM_ACTION_JUNK_DESTROY_WORTHLESS, "В хлам или уничтожить, если цена 0з", 1)
+SafeAddString(SI_PA_ITEM_ACTION_DESTROY_ALWAYS, "Всегда уничтожать", 1)
 
 
 -- =================================================================================================================

--- a/PersonalAssistant/localization/ru.lua
+++ b/PersonalAssistant/localization/ru.lua
@@ -1,0 +1,179 @@
+local PAC = PersonalAssistant.Constants
+-- =================================================================================================================
+-- Language specific texts that need to be translated --
+
+-- Welcome Messages --
+SafeAddString(SI_PA_WELCOME_NO_SUPPORT, table.concat({PAC.COLORS.DEFAULT, " к вашим услугам!  -  [%s] локализация пока не поддерживается"}), 1)
+SafeAddString(SI_PA_WELCOME_SUPPORT, table.concat({PAC.COLORS.DEFAULT, " к вашим услугам!"}), 1)
+SafeAddString(SI_PA_WELCOME_PLEASE_SELECT_PROFILE, table.concat({PAC.COLORS.DEFAULT, " приветствую вас! Прежде чем начать, перейдите в меню настроек дополнений и выберите профиль (или введите ",PAC.COLORS.WHITE,"/pa", PAC.COLORS.DEFAULT, "). Спасибо :-)"}), 1)
+
+SafeAddString(SI_PA_LAM_OUTDATED, table.concat({PAC.COLORS.ORANGE_RED, " требуется более свежая версия '", PAC.COLORS.WHITE, "LibAddonMenu-2.0", PAC.COLORS.ORANGE_RED, "' чем в настоящее время установлена. Пожалуйста, скачайте и установите последнюю версию с ", PAC.COLORS.WHITE, "http://esoui.com"}), 1)
+
+
+-- =================================================================================================================
+-- == MENU/PANEL TEXTS == --
+-- -----------------------------------------------------------------------------------------------------------------
+SafeAddString(SI_PA_MENU_GENERAL_DESCRIPTION, "PersonalAssistant представляет собой набор различных функций, цель которых сделать игру более удобной для вас", 1)
+
+-- Profiles --
+SafeAddString(SI_PA_MENU_PROFILE_HEADER, "Профили", 1)
+SafeAddString(SI_PA_MENU_PROFILE_PLEASE_SELECT, "<Выберите профиль>", 1)
+SafeAddString(SI_PA_MENU_PROFILE_ACTIVE, "Текущий профиль", 1)
+SafeAddString(SI_PA_MENU_PROFILE_ACTIVE_T, "Выберите профиль для PersonalAssistant. Он автоматически загрузит все настройки, сохраненные в этом профиле, и все изменения будут сохранены в том же месте.", 1)
+SafeAddString(SI_PA_MENU_PROFILE_ACTIVE_RENAME, "Переименовать", 1)
+
+-- General --
+SafeAddString(SI_PA_MENU_GENERAL_SHOW_WELCOME, "Показывать приветственное сообщение", 1)
+SafeAddString(SI_PA_MENU_GENERAL_TELEPORT_PRIMARY_HOUSE, table.concat({PAC.ICONS.OTHERS.HOME.NORMAL, " Домой"}), 1)
+SafeAddString(SI_PA_MENU_GENERAL_TELEPORT_PRIMARY_HOUSE_W, "Если текущее местоположение допускает быстрые перемещения, это инициирует телепорт в ваш основной дом!", 1)
+
+-- -----------------------------------------------------------------------------------------------------------------
+-- Rules Menu --
+SafeAddString(SI_PA_MENU_RULES_HOW_TO_ADD_PAB, "Чтобы создать новое правило для ввода и вывода предметов, просто щелкните правой кнопкой мыши на предмете в вашем инвентаре или банке и выберите в контекстном меню:\nPA Banking > Добавить новое правило", 1)
+SafeAddString(SI_PA_MENU_RULES_HOW_TO_ADD_PAJ, "Чтобы создать новое правило для постоянной пометки элемента как хлам, просто щелкните правой кнопкой мыши на предмете в вашем инвентаре или банке и выберите в контекстном меню:\nPA Junk > Пометить как хлам", 1)
+SafeAddString(SI_PA_MENU_RULES_HOW_TO_FIND_MENU, table.concat({"Вы можете увидеть все активные правила нажав на иконку в главном меню, которое вы можете открыть с помощью клавиши [Alt], через команду ", PAC.COLOR.YELLOW:Colorize("/parules"), " или нажав на эту кнопку:"}), 1)
+SafeAddString(SI_PA_MENU_RULES_HOW_TO_CREATE, "Как создать новое правило?", 1)
+
+SafeAddString(SI_PA_MENU_DANGEROUS_SETTING, "ВНИМАНИЕ: Опасная настройка! Используйте на свой страх и риск!", 1)
+
+-- -----------------------------------------------------------------------------------------------------------------
+-- Generic Menu --
+SafeAddString(SI_PA_MENU_OTHER_SETTINGS_HEADER, "Другие настройки", 1)
+
+SafeAddString(SI_PA_MENU_SILENT_MODE, "Тихий режим (отключить ВСЕ сообщения чата)", 1)
+
+SafeAddString(SI_PA_MENU_NOT_YET_IMPLEMENTED, table.concat({PAC.COLORS.RED, "Еще не реализовано!"}), 1)
+
+
+-- =================================================================================================================
+-- == CHAT OUTPUTS == --
+-- -----------------------------------------------------------------------------------------------------------------
+-- PAGeneral --
+SafeAddString(SI_PA_CHAT_GENERAL_ACTIVE_PROFILE_ACTIVE, table.concat({PAC.COLORS.DEFAULT, " текущий профиль: ", PAC.COLORS.ORANGE_RED, "%s"}), 1)
+
+
+-- =================================================================================================================
+-- == OTHER STRINGS FOR MENU == --
+-- -----------------------------------------------------------------------------------------------------------------
+-- PAGeneral --
+SafeAddString(SI_PA_PROFILE, "Профиль", 1)
+
+-- -----------------------------------------------------------------------------------------------------------------
+-- Name Spaces --
+SafeAddString(SI_PA_NS_BAG_EQUIPMENT, "", 1) -- not required so far
+SafeAddString(SI_PA_NS_BAG_BACKPACK, "Инвентарь", 1)
+SafeAddString(SI_PA_NS_BAG_BANK, "Банк", 1)
+SafeAddString(SI_PA_NS_BAG_SUBSCRIBER_BANK, "ESO Plus банк", 1)
+SafeAddString(SI_PA_NS_BAG_UNKNOWN, "Неизвестно", 1)
+
+-- -----------------------------------------------------------------------------------------------------------------
+-- ItemTypes (Custom Singluar/Plural definition) --
+SafeAddString(SI_PA_ITEMTYPE4, "<<1[Еда/Еда]>>", 1) -- ITEMTYPE_FOOD
+SafeAddString(SI_PA_ITEMTYPE5, "<<1[Трофей/Трофеи]>>", 1) -- ITEMTYPE_TROPHY
+SafeAddString(SI_PA_ITEMTYPE7, "<<1[Зелье/Зелья]>>", 1) -- ITEMTYPE_POTION
+SafeAddString(SI_PA_ITEMTYPE8, "<<1[Мотив/Мотивы]>>", 1) -- ITEMTYPE_RACIAL_STYLE_MOTIF
+SafeAddString(SI_PA_ITEMTYPE12, "<<1[Напиток/Напитки]>>", 1) -- ITEMTYPE_DRINK
+SafeAddString(SI_PA_ITEMTYPE22, "<<1[Отмычка/Отмычки]>>", 1) -- todo: unused
+SafeAddString(SI_PA_ITEMTYPE19, "<<1[Камень душ/Камни душ]>>", 1) -- ITEMTYPE_SOUL_GEM
+SafeAddString(SI_PA_ITEMTYPE29, "<<1[Рецепт/Рецепты]>>", 1) -- ITEMTYPE_RECIPE
+SafeAddString(SI_PA_ITEMTYPE30, "<<1[Яд/Яды]>>", 1) -- ITEMTYPE_POISON
+SafeAddString(SI_PA_ITEMTYPE34, "<<1[Коллекционный предмет/Коллекционные предметы]>>", 1) -- ITEMTYPE_COLLECTIBLE
+SafeAddString(SI_PA_ITEMTYPE47, "<<1[Ремонтный набор войны альянсов/Ремонтные наборы войны альянсов]>>", 1) -- todo: unused
+SafeAddString(SI_PA_ITEMTYPE60, "<<1[Мастерский заказ/Мастерские заказы]>>", 1) -- ITEMTYPE_MASTER_WRIT
+
+-- -----------------------------------------------------------------------------------------------------------------
+-- Master Writs based on CraftingType (Custom definition) --
+SafeAddString(SI_PA_MASTERWRIT_CRAFTINGTYPE0, table.concat({"Другие заказы (", GetString("SI_ENCHANTMENTSEARCHCATEGORYTYPE", ENCHANTMENT_SEARCH_CATEGORY_OTHER), ")"}), 1)
+SafeAddString(SI_PA_MASTERWRIT_CRAFTINGTYPE1, "Запечатанный заказ кузнецу", 1)
+SafeAddString(SI_PA_MASTERWRIT_CRAFTINGTYPE2, "Запечатанный заказ портному", 1)
+SafeAddString(SI_PA_MASTERWRIT_CRAFTINGTYPE3, "Запечатанный заказ зачарователю", 1)
+SafeAddString(SI_PA_MASTERWRIT_CRAFTINGTYPE4, "Запечатанный заказ алхимику", 1)
+SafeAddString(SI_PA_MASTERWRIT_CRAFTINGTYPE5, "Запечатанный заказ снабженцу", 1)
+SafeAddString(SI_PA_MASTERWRIT_CRAFTINGTYPE6, "Запечатанный заказ столяру", 1)
+SafeAddString(SI_PA_MASTERWRIT_CRAFTINGTYPE7, "Запечатанный заказ ювелиру", 1)
+
+-- -----------------------------------------------------------------------------------------------------------------
+-- PABanking --
+SafeAddString(SI_PA_BANKING_MOVE_MODE_DONOTHING, "Ничего не делать", 1)
+SafeAddString(SI_PA_BANKING_MOVE_MODE_TOBANK, "Переместить в банк", 1)
+SafeAddString(SI_PA_BANKING_MOVE_MODE_TOBACKPACK, "Переместить в инвентарь", 1)
+
+SafeAddString(SI_PA_MENU_BANKING_ADVANCED_GLYPHS, "Глифы", 1)
+SafeAddString(SI_PA_MENU_BANKING_ADVANCED_INTRICATE_ITEMS, "Предметы с особенностью Intricate", 1)
+
+SafeAddString(SI_PA_MENU_BANKING_REPAIRKIT, "Ремонтные наборы", 1)
+
+-- -----------------------------------------------------------------------------------------------------------------
+-- Operators --
+SafeAddString(SI_PA_REL_OPERATOR_T, "Выберите математический оператор для этого предмета", 1)
+SafeAddString(SI_PA_REL_BACKPACK_EQUAL, "В ИНВЕНТАРЕ ==", 1)
+SafeAddString(SI_PA_REL_BACKPACK_LESSTHAN, "В ИНВЕНТАРЕ <", 1) -- not used so far
+SafeAddString(SI_PA_REL_BACKPACK_LESSTHANEQUAL, "В ИНВЕНТАРЕ <=", 1)
+SafeAddString(SI_PA_REL_BACKPACK_GREATERTHAN, "В ИНВЕНТАРЕ >", 1) -- not used so far
+SafeAddString(SI_PA_REL_BACKPACK_GREATERTHANEQUAL, "В ИНВЕНТАРЕ >=", 1)
+SafeAddString(SI_PA_REL_BANK_EQUAL, "В БАНКЕ ==", 1)
+SafeAddString(SI_PA_REL_BANK_LESSTHAN, "В БАНКЕ <", 1) -- not used so far
+SafeAddString(SI_PA_REL_BANK_LESSTHANOREQUAL, "В БАНКЕ <=", 1)
+SafeAddString(SI_PA_REL_BANK_GREATERTHAN, "В БАНКЕ >", 1) -- not used so far
+SafeAddString(SI_PA_REL_BANK_GREATERTHANOREQUAL, "В БАНКЕ >=", 1)
+
+-- -----------------------------------------------------------------------------------------------------------------
+-- Operator Tooltip --
+SafeAddString(SI_PA_REL_BACKPACK_EQUAL_T, "В ИНВЕНТАРЕ ровно (==)", 1)
+SafeAddString(SI_PA_REL_BACKPACK_LESSTHAN_T, "В ИНВЕНТАРЕ менее (<)", 1) -- not used so far
+SafeAddString(SI_PA_REL_BACKPACK_LESSTHANOREQUAL_T, "В ИНВЕНТАРЕ менее или равно (<=)", 1)
+SafeAddString(SI_PA_REL_BACKPACK_GREATERTHAN_T, "В ИНВЕНТАРЕ более (>)", 1) -- not used so far
+SafeAddString(SI_PA_REL_BACKPACK_GREATERTHANOREQUAL_T, "В ИНВЕНТАРЕ более или равно (>=)", 1)
+SafeAddString(SI_PA_REL_BANK_EQUAL_T, "В БАНКЕ ровно (==)", 1)
+SafeAddString(SI_PA_REL_BANK_LESSTHAN_T, "В БАНКЕ менее (<)", 1) -- not used so far
+SafeAddString(SI_PA_REL_BANK_LESSTHANOREQUAL_T, "В БАНКЕ менее или равно (<=)", 1)
+SafeAddString(SI_PA_REL_BANK_GREATERTHAN_T, "В БАНКЕ более (>)", 1) -- not used so far
+SafeAddString(SI_PA_REL_BANK_GREATERTHANOREQUAL_T, "В БАНКЕ более или равно (>=)", 1)
+
+-- -----------------------------------------------------------------------------------------------------------------
+-- Stacking types --
+SafeAddString(SI_PA_ST_MOVE_FULL, "Переместить всё", 1) -- 0: Full deposit
+SafeAddString(SI_PA_ST_MOVE_INCOMPLETE_STACKS_ONLY, "Заполнить только существующие стеки", 1) -- 1: Fill existing stacks
+
+-- -----------------------------------------------------------------------------------------------------------------
+-- Icon Positions --
+SafeAddString(SI_PA_POSITION_AUTO, "Автоматически", 1)
+SafeAddString(SI_PA_POSITION_TOPLEFT, "Вверху слева", 1)
+SafeAddString(SI_PA_POSITION_TOPRIGHT, "Вверху справа", 1)
+SafeAddString(SI_PA_POSITION_BOTTOMLEFT, "Внизу слева", 1)
+SafeAddString(SI_PA_POSITION_BOTTOMRIGHT, "Внизу справа", 1)
+
+
+-- =================================================================================================================
+-- == CUSTOM SUB MENU == --
+-- -----------------------------------------------------------------------------------------------------------------
+SafeAddString(SI_PA_SUBMENU_PAB_ADD_RULE, "Добавить новое правило", 1)
+SafeAddString(SI_PA_SUBMENU_PAB_EDIT_RULE, "Изменить правило", 1)
+SafeAddString(SI_PA_SUBMENU_PAB_DELETE_RULE, "Удалить правило", 1)
+SafeAddString(SI_PA_SUBMENU_PAB_ADD_RULE_BUTTON, "Добавить", 1)
+SafeAddString(SI_PA_SUBMENU_PAB_UPDATE_RULE_BUTTON, "Сохранить", 1)
+SafeAddString(SI_PA_SUBMENU_PAB_DELETE_RULE_BUTTON, "Удалить", 1)
+SafeAddString(SI_PA_SUBMENU_PAB_NO_RULES, "Не задано правил для банкинга", 1)
+SafeAddString(SI_PA_SUBMENU_PAB_DISCLAIMER, "Замечание: эти пользовательские правила будут обработаны после всех автоматических правил (ремесленных предметов, особых предметов и предметов войны альянсов).", 1)
+
+SafeAddString(SI_PA_SUBMENU_PAJ_MARK_PERM_JUNK, "Пометить как хлам", 1)
+SafeAddString(SI_PA_SUBMENU_PAJ_UNMARK_PERM_JUNK, "Убрать пометку как хлам", 1)
+SafeAddString(SI_PA_SUBMENU_PAJ_NO_RULES, "Не задано правил для хлама", 1)
+
+
+-- =================================================================================================================
+-- == KEY BINDINGS == --
+-- -----------------------------------------------------------------------------------------------------------------
+SafeAddString(SI_KEYBINDINGS_CATEGORY_PA_PROFILES, "|cFFD700P|rersonal|cFFD700A|rssistant Профили", 1)
+SafeAddString(SI_KEYBINDINGS_CATEGORY_PA_MENU, "|cFFD700P|rersonal|cFFD700A|rssistant Меню", 1)
+
+SafeAddString(SI_BINDING_NAME_PA_RULES_MAIN_MENU, "PersonalAssistant Правила", 1)
+SafeAddString(SI_BINDING_NAME_PA_RULES_TOGGLE_WINDOW, "Переключить меню правил Банкинга/Хлама", 1)
+
+SafeAddString(SI_KEYBINDINGS_PA_LOAD_PROFILE, "Активировать профиль", 1)
+
+-- =================================================================================================================
+-- == CUSTOM SUB MENU == --
+-- -----------------------------------------------------------------------------------------------------------------
+SafeAddString(SI_PA_SUBMENU_PAB, "|cFFD700PA|r Banking", 1)
+SafeAddString(SI_PA_SUBMENU_PAJ, "|cFFD700PA|r Junk", 1)


### PR DESCRIPTION
Hey. 

I liked this addon, I use it and decided to make Russian localization for it. Most texts are translated correctly, but there are some errors in the translation. Currently, the Russian language is not officially supported by the game client, and some functions that work correctly for official languages ​​does not work in Russian. 

For example: `zo_strformat("<<m:1>>", GetString ("SI_ITEMFILTERTYPE", .....))`. If the Russian word has the same singular and plural number, then you will get the Russian word at the end of which the letter S is added. And this spoils the quality of the translation. This is especially noticeable in the PABanking submenu: Glyphs, Potions and Poisons, Food and Drinks, Trophies and Intricate items. Almost all of the items in this submenu have the letter S in the translation at the end of the name. 

The same goes for PAJunk - Collectibles, Weapons, Armor and Jewelry (submenu headers and items) and Stolen items (only items Armor, Weapons and Jewelry), and if I can replace the headings in the localization file, then I cannot change the items in the submenu, because they do not have a variable to translate in the source language. 

A replacement for plural to singular - `zo_strformat("<<s:1>>", GetString ("SI_ITEMFILTERTYPE", .....))` - could help, but I'm not sure that this will work correctly for other languages.  Also, `zo_strformat(GetString("SI_PA_ITEMTYPE", ITEMTYPE_.....), 2)` works correctly  because the singular and plural are present in translations. 

I also corrected the translation of the submenu heading Glyphs in all languages. I update fork the repository and try to quickly make new translations if they need. And I can make pull request if you need it.