### PR TITLE
PAJ: dont mark crafted items

### DIFF
--- a/PersonalAssistant/PersonalAssistantJunk/Menu/PAJunkMenu.lua
+++ b/PersonalAssistant/PersonalAssistantJunk/Menu/PAJunkMenu.lua
@@ -214,6 +214,16 @@ local function _createPAJunkMenu()
 
     PAJunkOptionsTable:insert({
         type = "checkbox",
+        name = GetString(SI_PA_MENU_JUNK_CRAFTED_IGNORE),
+        tooltip = GetString(SI_PA_MENU_JUNK_CRAFTED_IGNORE_T),
+        getFunc = PAJMenuFunctions.getCraftedItemsIgnoredSetting,
+        setFunc = PAJMenuFunctions.setCraftedItemsIgnoredSetting,
+        disabled = PAJMenuFunctions.isCraftedItemsIgnoredDisabled,
+        default = PAJMenuDefaults.ignoreCraftedItems,
+    })
+
+    PAJunkOptionsTable:insert({
+        type = "checkbox",
         name = GetString(SI_PA_MENU_JUNK_AUTOSELL_JUNK),
         getFunc = PAJMenuFunctions.getAutoSellJunkSetting,
         setFunc = PAJMenuFunctions.setAutoSellJunkSetting,

--- a/PersonalAssistant/PersonalAssistantJunk/Menu/PAJunkMenuDefaults.lua
+++ b/PersonalAssistant/PersonalAssistantJunk/Menu/PAJunkMenuDefaults.lua
@@ -81,6 +81,7 @@ local PAJunkMenuDefaults = {
     },
 
     ignoreMailboxItems = true,
+    ignoreCraftedItems = true,
     autoSellJunk = true,
     autoSellJunkPirharri = false,
 

--- a/PersonalAssistant/PersonalAssistantJunk/Menu/PAJunkMenuFunctions.lua
+++ b/PersonalAssistant/PersonalAssistantJunk/Menu/PAJunkMenuFunctions.lua
@@ -372,6 +372,13 @@ local PAJunkMenuFunctions = {
     setMailboxItemsIgnoredSetting = function(value) setValue(value, {"ignoreMailboxItems"}) end,
 
     -- ----------------------------------------------------------------------------------
+    -- CRAFTED ITEMS
+    -- -----------------------------
+    isCraftedItemsIgnoredDisabled = function() return isDisabled() end, -- currently always enabled
+    getCraftedItemsIgnoredSetting = function() return getValue({"ignoreCraftedItems"}) end,
+    setCraftedItemsIgnoredSetting = function(value) setValue(value, {"ignoreCraftedItems"}) end,
+
+    -- ----------------------------------------------------------------------------------
     -- AUTO SELL JUNK
     -- -----------------------------
     isAutoSellJunkDisabled = function() return isDisabled() end, -- currently always enabled

--- a/PersonalAssistant/PersonalAssistantJunk/PAJunk/PAJunk.lua
+++ b/PersonalAssistant/PersonalAssistantJunk/PAJunk/PAJunk.lua
@@ -658,14 +658,16 @@ end
 
 local function OnInventorySingleSlotUpdate(eventCode, bagId, slotIndex, isNewItem, itemSoundCategory, inventoryUpdateReason, stackCountChange)
     if PAHF.hasActiveProfile() then
-        -- only proceed, if neither the crafting window nor the mailbox are open (otherwise crafted/retrieved items could also be marked as junk)
-        -- unless the mailbox setting is overriden
+        -- only proceed it item is not already marked as junk
+        local isJunk = IsItemJunk(bagId, slotIndex)
+        if isJunk then return end
+        -- then only further proceed, if item is not crafted at not coming from the mailbox (unless the corresponding settings are turned off)
         local PAJunkSavedVars = PAJ.SavedVars
-        if not ZO_CraftingUtils_IsCraftingWindowOpen() and (PA.WindowStates.isMailboxClosed or not PAJunkSavedVars.ignoreMailboxItems) then
+        local itemLink = PAHF.getFormattedItemLink(bagId, slotIndex)
+        local isCrafted = IsItemLinkCrafted(itemLink)
+        if (not isCrafted or not PAJunkSavedVars.ignoreCraftedItems) and (PA.WindowStates.isMailboxClosed or not PAJunkSavedVars.ignoreMailboxItems) then
             -- check if the updated happened in the backpack and if the item is new
-            if isNewItem and bagId == BAG_BACKPACK then
-                -- get the itemLink (must use this function as GetItemLink returns all lower-case item-names) and itemType
-                local itemLink = PAHF.getFormattedItemLink(bagId, slotIndex)
+            if bagId == BAG_BACKPACK then
                 -- check if auto-marking is enabled for standard items
                 if PAJunkSavedVars.autoMarkAsJunkEnabled then
                     local itemType, specializedItemType = GetItemType(bagId, slotIndex)

--- a/PersonalAssistant/PersonalAssistantJunk/localization/de.lua
+++ b/PersonalAssistant/PersonalAssistantJunk/localization/de.lua
@@ -56,6 +56,8 @@ SafeAddString(SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_W, "ACHTUNG: Bitte beachte dass 
 -- Other Settings --
 SafeAddString(SI_PA_MENU_JUNK_MAILBOX_IGNORE, "Aus Nachrichten nie als Trödel markieren", 1)
 SafeAddString(SI_PA_MENU_JUNK_MAILBOX_IGNORE_T, "Aus Nachrichten entnommene Gegenstände sollen nie als Trödel markiert werden", 1)
+SafeAddString(SI_PA_MENU_JUNK_CRAFTED_IGNORE, "An Stationen hergestellt nie als Trödel markieren", 1)
+SafeAddString(SI_PA_MENU_JUNK_CRAFTED_IGNORE_T, "An Handwerksstationen selber hergestellte Gegenstände sollen nie als Trödel markiert werden", 1)
 SafeAddString(SI_PA_MENU_JUNK_AUTOSELL_JUNK, "Trödel direkt an Händler und Hehler verkaufen?", 1)
 SafeAddString(SI_PA_MENU_JUNK_AUTOSELL_JUNK_PIRHARRI, "Auch an Pirharri verkaufen? (Schmuggler Gehilfe)", 1)
 SafeAddString(SI_PA_MENU_JUNK_AUTOSELL_JUNK_PIRHARRI_W, "Im Gegensatz zu anderen Schmugglern behält Pirharri 35% des Profits für sich selbst", 1)

--- a/PersonalAssistant/PersonalAssistantJunk/localization/en.lua
+++ b/PersonalAssistant/PersonalAssistantJunk/localization/en.lua
@@ -60,6 +60,8 @@ local PAJStrings = {
     -- Other Settings --
     SI_PA_MENU_JUNK_MAILBOX_IGNORE = "Never mark items received from Mailbox as Junk",
     SI_PA_MENU_JUNK_MAILBOX_IGNORE_T = "Items that are received from Mailbox should never be marked as Junk",
+    SI_PA_MENU_JUNK_CRAFTED_IGNORE = "Never mark items you have crafted as Junk",
+    SI_PA_MENU_JUNK_CRAFTED_IGNORE_T = "Item that you have crafted at a Crafting Station should never be marked as Junk",
     SI_PA_MENU_JUNK_AUTOSELL_JUNK = "Auto-Sell Junk at Merchants and Fences?",
     SI_PA_MENU_JUNK_AUTOSELL_JUNK_PIRHARRI = "Also auto-sell to Pirharri? (Fence Assistant)",
     SI_PA_MENU_JUNK_AUTOSELL_JUNK_PIRHARRI_W = "Unlike other fences, Pirharri charges a Smuggler's Fee of 35% for availing of her service",

--- a/PersonalAssistant/PersonalAssistantJunk/localization/fr.lua
+++ b/PersonalAssistant/PersonalAssistantJunk/localization/fr.lua
@@ -56,6 +56,8 @@ SafeAddString(SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_W, "ATTENTION: Soyez conscient e
 -- Other Settings --
 SafeAddString(SI_PA_MENU_JUNK_MAILBOX_IGNORE, "Ne pas mettre aux rebuts si reçu par courrier", 1)
 SafeAddString(SI_PA_MENU_JUNK_MAILBOX_IGNORE_T, "Ne jamais mettre aux rebuts des objets reçus du courrier", 1)
+--SafeAddString(SI_PA_MENU_JUNK_CRAFTED_IGNORE, "", 1)
+--SafeAddString(SI_PA_MENU_JUNK_CRAFTED_IGNORE_T, "", 1)
 SafeAddString(SI_PA_MENU_JUNK_AUTOSELL_JUNK, "Vente/Recel auto. des rebuts aux marchands", 1)
 --SafeAddString(SI_PA_MENU_JUNK_AUTOSELL_JUNK_PIRHARRI, "", 1)
 --SafeAddString(SI_PA_MENU_JUNK_AUTOSELL_JUNK_PIRHARRI_W, "", 1)

--- a/PersonalAssistant/Utilities/SavedVarsPatcher.lua
+++ b/PersonalAssistant/Utilities/SavedVarsPatcher.lua
@@ -462,7 +462,9 @@ local function _applyPatch_2_5_1(savedVarsVersion, _, _, _, patchPAJ, _, _)
     if patchPAJ and PA then
         local PASavedVars = PA.SavedVars
         for profileNo = 1, PASavedVars.General.profileCounter do
-            PASavedVars.Junk[profileNo].ignoreCraftedItems = true
+            if istable(PASavedVars.Junk[profileNo]) then
+                PASavedVars.Junk[profileNo].ignoreCraftedItems = true
+            end
         end
         _updateSavedVarsVersion(savedVarsVersion, nil, nil, nil, patchPAJ, nil, nil)
     end

--- a/PersonalAssistant/Utilities/SavedVarsPatcher.lua
+++ b/PersonalAssistant/Utilities/SavedVarsPatcher.lua
@@ -351,7 +351,6 @@ local function _applyPatch_2_4_13(savedVarsVersion, _, _, _, _, patchPAL, _)
 end
 
 
--- local function _applyPatch_x_x_x(savedVarsVersion, patchPAG, patchPAB, patchPAI, patchPAJ, patchPAL, patchPAR)
 local function _applyPatch_2_4_14(savedVarsVersion, _, patchPAB, _, _, _, _)
     if patchPAB then
         local PASavedVars = PA.SavedVars
@@ -458,6 +457,16 @@ local function _applyPatch_2_5_0(savedVarsVersion, patchPAG, _, _, _, _, _)
     end
 end
 
+-- local function _applyPatch_x_x_x(savedVarsVersion, patchPAG, patchPAB, patchPAI, patchPAJ, patchPAL, patchPAR)
+local function _applyPatch_2_5_1(savedVarsVersion, _, _, _, patchPAJ, _, _)
+    if patchPAJ and PA then
+        local PASavedVars = PA.SavedVars
+        for profileNo = 1, PASavedVars.General.profileCounter do
+            PASavedVars.Junk[profileNo].ignoreCraftedItems = true
+        end
+        _updateSavedVarsVersion(savedVarsVersion, nil, nil, nil, patchPAJ, nil, nil)
+    end
+end
 
 -- ---------------------------------------------------------------------------------------------------------------------
 
@@ -509,6 +518,9 @@ local function applyPatchIfNeeded()
 
     -- Patch 2.5.0      October 03, 2020
     _applyPatch_2_5_0(_getIsPatchNeededInfo(020500))
+
+    -- Patch 2.5.0
+    _applyPatch_2_5_1(_getIsPatchNeededInfo(020501))
 end
 
 -- ---------------------------------------------------------------------------------------------------------------------

--- a/PersonalAssistant/vars/Globals.lua
+++ b/PersonalAssistant/vars/Globals.lua
@@ -47,7 +47,7 @@ PersonalAssistant.Constants = {
                 LOOT = 2,
                 REPAIR = 1,
             },
-            MINOR = 020500, -- update this every release!
+            MINOR = 020501, -- update this every release!
         },
     },
 


### PR DESCRIPTION
Basically resolves #258 by introducing an option to explicitely exclude crafted items from being marked as junk.
This also replaces the condition that no items can be marked as junk when the crafting sation is open.

Furthermore, it also removes the limtiation of only marking "new" items as junk