### PR TITLE
PAJ: fixed "ignore mailbox items" setting

### DIFF
--- a/PersonalAssistant/PersonalAssistantJunk/Menu/PAJunkMenuFunctions.lua
+++ b/PersonalAssistant/PersonalAssistantJunk/Menu/PAJunkMenuFunctions.lua
@@ -367,7 +367,7 @@ local PAJunkMenuFunctions = {
     -- ----------------------------------------------------------------------------------
     -- MAILBOX ITEMS
     -- -----------------------------
-    isMailboxItemsIgnoredDisabled = isPAJunkStolenMenuDisabled,
+    isMailboxItemsIgnoredDisabled = function() return isDisabled() end, -- currently always enabled
     getMailboxItemsIgnoredSetting = function() return getValue({"ignoreMailboxItems"}) end,
     setMailboxItemsIgnoredSetting = function(value) setValue(value, {"ignoreMailboxItems"}) end,
 


### PR DESCRIPTION
make "Never mark items received from Mailbox as Junk" always enabled (instead of wrongly based on Stolen Junk settings)