### PR TITLE
PA: overall performance improvements

### DIFF
--- a/PersonalAssistant/PersonalAssistantBanking/PABanking/PABankingCommon.lua
+++ b/PersonalAssistant/PersonalAssistantBanking/PABanking/PABankingCommon.lua
@@ -313,7 +313,7 @@ local function doIndividualItemTransactions(individualItems, backpackBagCache, b
             local itemData = configuredBagCache[index]
             local backpackItemId
             if isCustomPAItemIdList then
-                backpackItemId = PAHF.getPAItemIdentifier(itemData.bagId, itemData.slotIndex)
+                backpackItemId = PAHF.getPAItemIdentifierFromItemData(itemData)
             else
                 backpackItemId = GetItemId(itemData.bagId, itemData.slotIndex)
             end
@@ -341,7 +341,7 @@ local function doIndividualItemTransactions(individualItems, backpackBagCache, b
             local itemData = otherBagCache[index]
             local bankItemId
             if isCustomPAItemIdList then
-                bankItemId = PAHF.getPAItemIdentifier(itemData.bagId, itemData.slotIndex)
+                bankItemId = PAHF.getPAItemIdentifierFromItemData(itemData)
             else
                 bankItemId = GetItemId(itemData.bagId, itemData.slotIndex)
             end

--- a/PersonalAssistant/PersonalAssistantLoot/PALoot/PALootItemIcons.lua
+++ b/PersonalAssistant/PersonalAssistantLoot/PALoot/PALootItemIcons.lua
@@ -226,6 +226,14 @@ local function _addItemKnownOrUnknownVisuals(parentControl, itemLink, hookType)
     end
 end
 
+local function _getOrCreateDataEntryItemLink(dataEntryData)
+    if dataEntryData.itemLink == nil then
+        dataEntryData.itemLink = GetItemLink(dataEntryData.bagId, dataEntryData.slotIndex)
+    end
+    return dataEntryData.itemLink
+end
+
+
 -- ---------------------------------------------------------------------------------------------------------------------
 
 local function refreshScrollListVisible()
@@ -251,7 +259,7 @@ local function initHooksOnBags()
                 ZO_PreHook(listView.dataTypes[1], "setupCallback", function(control, slot)
                     local bagId = control.dataEntry.data.bagId
                     local slotIndex = control.dataEntry.data.slotIndex
-                    local itemLink = GetItemLink(bagId, slotIndex)
+                    local itemLink = _getOrCreateDataEntryItemLink(control.dataEntry.data)
                     _addItemKnownOrUnknownVisuals(control, itemLink, HOOK_BAGS)
                 end)
             end
@@ -316,7 +324,7 @@ local function initHooksOnCraftingStations()
             if control.slotControlType and control.slotControlType == 'listSlot' and control.dataEntry.data.slotIndex then
                 local bagId = control.dataEntry.data.bagId
                 local slotIndex = control.dataEntry.data.slotIndex
-                local itemLink = GetItemLink(bagId, slotIndex)
+                local itemLink = _getOrCreateDataEntryItemLink(control.dataEntry.data)
                 _addItemKnownOrUnknownVisuals(control, itemLink, HOOK_CRAFTSTATION)
             end
         end)
@@ -326,7 +334,7 @@ local function initHooksOnCraftingStations()
             if control.slotControlType and control.slotControlType == 'listSlot' and control.dataEntry.data.slotIndex then
                 local bagId = control.dataEntry.data.bagId
                 local slotIndex = control.dataEntry.data.slotIndex
-                local itemLink = GetItemLink(bagId, slotIndex)
+                local itemLink = _getOrCreateDataEntryItemLink(control.dataEntry.data)
                 _addItemKnownOrUnknownVisuals(control, itemLink, HOOK_CRAFTSTATION)
             end
         end)
@@ -336,7 +344,7 @@ local function initHooksOnCraftingStations()
             if control.slotControlType and control.slotControlType == 'listSlot' and control.dataEntry.data.slotIndex then
                 local bagId = control.dataEntry.data.bagId
                 local slotIndex = control.dataEntry.data.slotIndex
-                local itemLink = GetItemLink(bagId, slotIndex)
+                local itemLink = _getOrCreateDataEntryItemLink(control.dataEntry.data)
                 _addItemKnownOrUnknownVisuals(control, itemLink, HOOK_CRAFTSTATION)
             end
         end)

--- a/PersonalAssistant/Utilities/HelperFunctions.lua
+++ b/PersonalAssistant/Utilities/HelperFunctions.lua
@@ -79,6 +79,14 @@ local function getPAItemIdentifier(bagId, slotIndex)
     return getPAItemLinkIdentifier(itemLink)
 end
 
+local function getPAItemIdentifierFromItemData(itemData)
+    if not itemData.paItemId then
+        itemData.paItemId = getPAItemIdentifier(itemData.bagId, itemData.slotIndex)
+    end
+    return itemData.paItemId
+end
+
+
 
 -- =================================================================================================================
 -- == COMPARATORS == --
@@ -194,8 +202,9 @@ local function getPAItemIdComparator(paItemIdList, excludeJunk)
         if IsItemStolen(itemData.bagId, itemData.slotIndex) then return false end
         if IsItemJunk(itemData.bagId, itemData.slotIndex) and excludeJunk then return false end
         if _isItemCharacterBound(itemData.bagId, itemData.slotIndex) then return false end
-        for paItemId, _ in pairs(paItemIdList) do
-            if paItemId == getPAItemIdentifier(itemData.bagId, itemData.slotIndex) then return true end
+        local paItemId = itemData.paItemId or getPAItemIdentifierFromItemData(itemData)
+        for paItemIdFromList, _ in pairs(paItemIdList) do
+            if paItemIdFromList == paItemId then return true end
         end
         return false
     end
@@ -430,6 +439,7 @@ PA.HelperFunctions = {
     isKeyInTable = isKeyInTable,
     getPAItemLinkIdentifier = getPAItemLinkIdentifier,
     getPAItemIdentifier = getPAItemIdentifier,
+    getPAItemIdentifierFromItemData = getPAItemIdentifierFromItemData,
     getCombinedItemTypeSpecializedComparator = getCombinedItemTypeSpecializedComparator,
     getItemTypeComparator = getItemTypeComparator,
     getItemIdComparator = getItemIdComparator,


### PR DESCRIPTION
- re-use values that need to be calcualted (instead of calculating them again)
- store re-usable information in "itemData" table
- extract variable declaration outside for-loop

Noticable difference in ESO Profiler when accessing the bank for the first time:

![image](https://user-images.githubusercontent.com/14639044/97804715-f697bc00-1c51-11eb-9d60-5e52480d65bc.png)

| Function | Time Before  | Time After | Time Change | Calls Before  | Calls After | CallsChange | 
| ------------- | ------------- | ------------- | ------------- |------------- |------------- |------------- |
| < anonymous function > | 218ms | 30ms | 626% faster | 8 calls | 8 calls | - |
| depositOrWithdrawCustomItems | 202ms | 23ms | 778% faster | 1 call | 1 call | - |
| getPAIdemLinkIdentifier | 176ms | 21ms + 19ms | 340% faster | 3118 calls | 544+294 calls | 277% less calls |
| isValueInTable | 1.493ms | 0.023ms | 6391% faster | 1725 calls | 33 calls | 5127% less calls |
| _getCraftingTypeFromWritItemLink | 1.446ms | 0.055ms | 2529% faster | 1869 calls | 130 calls | 1337% less calls |

An additional performance improvement of up to 200% can be expected for subsequent bank visits when cached data can be utilized.