### PR TITLE
PAJunk: Revert "PAJunk: skip items that are "cannot sell" (#335)"

### DIFF
--- a/PersonalAssistant/Menu/ItemContextMenu.lua
+++ b/PersonalAssistant/Menu/ItemContextMenu.lua
@@ -6,11 +6,6 @@ local PAHF = PA.HelperFunctions
 
 local _hooksOnInventoryContextMenuInitialized = false
 
-local function _isItemCannotSell(bagId, slotIndex)
-    local sellInformation = GetItemSellInformation(bagId, slotIndex)
-    return sellInformation == ITEM_SELL_INFORMATION_CANNOT_SELL
-end
-
 local function _isBankingRuleNotAllowed(itemLink, bagId, slotIndex)
     local itemType = GetItemType(bagId, slotIndex)
     if itemType == ITEMTYPE_RACIAL_STYLE_MOTIF then return true end
@@ -62,7 +57,7 @@ local function _addDynamicContextMenuEntries(itemLink, bagId, slotIndex)
     end
 
     -- Add PAJunk context menu entries
-    if PA.Junk and PA.Junk.SavedVars.Custom.customItemsEnabled and not _isItemCannotSell(bagId, slotIndex) then
+    if PA.Junk and PA.Junk.SavedVars.Custom.customItemsEnabled then
         local PAJCustomPAItemIds = PA.Junk.SavedVars.Custom.PAItemIds
         local canBeMarkedAsJunk = CanItemBeMarkedAsJunk(bagId, slotIndex)
         local isRuleExisting = PAHF.isKeyInTable(PAJCustomPAItemIds, paItemId)

--- a/PersonalAssistant/PersonalAssistantJunk/PAJunk/PAJunkKeybindStrip.lua
+++ b/PersonalAssistant/PersonalAssistantJunk/PAJunk/PAJunkKeybindStrip.lua
@@ -7,16 +7,11 @@ local PAHF = PA.HelperFunctions
 
 local _mouseOverBagId, _mouseOverSlotIndex, _mouseOverStackCount, _mouseOverIsJunk
 
-local function _isItemCannotSell(bagId, slotIndex)
-    local sellInformation = GetItemSellInformation(bagId, slotIndex)
-    return sellInformation == ITEM_SELL_INFORMATION_CANNOT_SELL
-end
-
 local function _isMarkUnmarkAsJunkVisible()
     local PAJSV = PA.Junk.SavedVars
     if PAJSV and PAJSV.KeyBindings.enableMarkUnmarkAsJunkKeybind and PAJSV.KeyBindings.showMarkUnmarkAsJunkKeybind then
-        -- also return false when item cannot be sold, or is already marked as perm junk
-        if _isItemCannotSell(_mouseOverBagId, _mouseOverSlotIndex) or PA.Junk.Custom.isItemPermanentJunk(_mouseOverBagId, _mouseOverSlotIndex) then
+        -- also return false when item is already marked as perm junk
+        if PA.Junk.Custom.isItemPermanentJunk(_mouseOverBagId, _mouseOverSlotIndex) then
             return false
         end
         return _mouseOverBagId and _mouseOverSlotIndex
@@ -27,8 +22,8 @@ end
 local function _isMarkUnmarkAsJunkEnabled()
     local PAJSV = PA.Junk.SavedVars
     if PAJSV and PAJSV.KeyBindings.enableMarkUnmarkAsJunkKeybind then
-        -- also return false when item cannot be sold, or when item is already marked as perm junk
-        if _isItemCannotSell(_mouseOverBagId, _mouseOverSlotIndex) or PA.Junk.Custom.isItemPermanentJunk(_mouseOverBagId, _mouseOverSlotIndex) then
+        -- also return false when item is already marked as perm junk
+        if PA.Junk.Custom.isItemPermanentJunk(_mouseOverBagId, _mouseOverSlotIndex) then
             return false
         end
         return CanItemBeMarkedAsJunk(_mouseOverBagId, _mouseOverSlotIndex)
@@ -39,9 +34,6 @@ end
 local function _isMarkUnmarkAsPermJunkVisible()
     local PAJSV = PA.Junk.SavedVars
     if PAJSV and PAJSV.KeyBindings.enableMarkUnmarkAsPermJunkKeybind and PAJSV.KeyBindings.showMarkUnmarkAsPermJunkKeybind then
-        if _isItemCannotSell(_mouseOverBagId, _mouseOverSlotIndex) then
-            return false
-        end
         return _mouseOverBagId and _mouseOverSlotIndex
     end
     return false
@@ -50,9 +42,6 @@ end
 local function _isMarkUnmarkAsPermJunkEnabled()
     local PAJSV = PA.Junk.SavedVars
     if PAJSV and PAJSV.KeyBindings.enableMarkUnmarkAsPermJunkKeybind then
-        if _isItemCannotSell(_mouseOverBagId, _mouseOverSlotIndex) then
-            return false
-        end
         return CanItemBeMarkedAsJunk(_mouseOverBagId, _mouseOverSlotIndex)
     end
     return false
@@ -205,8 +194,6 @@ end
 local function toggleItemMarkedAsJunk()
     if PA.Junk.SavedVars and PA.Junk.SavedVars.KeyBindings.enableMarkUnmarkAsJunkKeybind then
         if _mouseOverBagId and _mouseOverSlotIndex then
-            -- only proceed if item has any value
-            if _isItemCannotSell(_mouseOverBagId, _mouseOverSlotIndex) then return end
             -- if item is already marked as permanent junk; skip function
             if PA.Junk.Custom.isItemPermanentJunk(_mouseOverBagId, _mouseOverSlotIndex) then return end
             -- get item information
@@ -229,8 +216,6 @@ local function toggleItemMarkedAsPermanentJunk()
     if PA.Junk.SavedVars and PAJ.SavedVars.Custom.customItemsEnabled and
             PA.Junk.SavedVars.KeyBindings.enableMarkUnmarkAsPermJunkKeybind then
         if _mouseOverBagId and _mouseOverSlotIndex then
-            -- only proceed if item has any value
-            if _isItemCannotSell(_mouseOverBagId, _mouseOverSlotIndex) then return end
             -- get item information
             local itemLinkPlain = GetItemLink(_mouseOverBagId, _mouseOverSlotIndex)
             if PA.Junk.Custom.isItemLinkPermanentJunk(itemLinkPlain) then

--- a/PersonalAssistant/Utilities/SavedVarsPatcher.lua
+++ b/PersonalAssistant/Utilities/SavedVarsPatcher.lua
@@ -549,6 +549,7 @@ local function _applyPatch_2_5_5(savedVarsVersion, _, patchPAB, _, _, _, _)
     end
 end
 
+-- local function _applyPatch_x_x_x(savedVarsVersion, patchPAG, patchPAB, patchPAI, patchPAJ, patchPAL, patchPAR)
 local function _applyPatch_2_5_10(savedVarsVersion, _, _, _, patchPAJ, _, _)
     if patchPAJ and PA.Junk then
         local PASavedVars = PA.SavedVars
@@ -565,26 +566,6 @@ local function _applyPatch_2_5_10(savedVarsVersion, _, _, _, patchPAJ, _, _)
             end
         end
         _updateSavedVarsVersion(savedVarsVersion, nil, nil, nil, patchPAJ, nil, nil)
-    end
-end
-
--- local function _applyPatch_x_x_x(savedVarsVersion, patchPAG, patchPAB, patchPAI, patchPAJ, patchPAL, patchPAR)
-local function _applyPatch_2_5_11(savedVarsVersion, _, _, _, patchPAJ, _, _)
-    if patchPAJ and PA.Junk then
-        local PASavedVars = PA.SavedVars
-        for profileNo = 1, PASavedVars.General.profileCounter do
-            if istable(PASavedVars.Junk[profileNo]) then
-                local PAJCustomPAItemIds = PASavedVars.Junk[profileNo].Custom.PAItemIds
-                for _, junkConfig in pairs(PAJCustomPAItemIds) do
-                    local itemLink = junkConfig.itemLink
-                    local sellInformation = GetItemLinkSellInformation(itemLink)
-                    if sellInformation == ITEM_SELL_INFORMATION_CANNOT_SELL then
-                        -- remove from permanent junk
-                        PA.Junk.Custom.removeItemLinkFromPermanentJunk(itemLink)
-                    end
-                end
-            end
-        end
     end
 end
 
@@ -653,9 +634,6 @@ local function applyPatchIfNeeded()
 
     -- Patch 2.5.10     March 18, 2021
     _applyPatch_2_5_10(_getIsPatchNeededInfo(020510))
-
-    -- Patch 2.5.11     tbd, 2021
-    _applyPatch_2_5_11(_getIsPatchNeededInfo(020511))
 end
 
 -- ---------------------------------------------------------------------------------------------------------------------

--- a/PersonalAssistant/vars/Globals.lua
+++ b/PersonalAssistant/vars/Globals.lua
@@ -48,7 +48,7 @@ PersonalAssistant.Constants = {
                 LOOT = 2,
                 REPAIR = 1,
             },
-            MINOR = 020511, -- update this every release!
+            MINOR = 020510, -- update this every release!
         },
     },
 


### PR DESCRIPTION
This reverts commit bcfdd60f (PR #335)

"Cannot sell" items should not be skipped, because otherwise the "destroy junk if worthless" setting is of no use anymore.