### PR TITLE
PAJunk: big refactoring with improved auto-destroy feature

### DIFF
--- a/PersonalAssistant/Menu/MenuChoices.lua
+++ b/PersonalAssistant/Menu/MenuChoices.lua
@@ -30,6 +30,14 @@ local PAMenuChoices = {
         },
     },
     PAJunk = {
+        qualityLevelNoDisabled = {
+            GetString(SI_PA_QUALITY_TRASH),
+            GetString(SI_PA_QUALITY_NORMAL),
+            GetString(SI_PA_QUALITY_FINE),
+            GetString(SI_PA_QUALITY_SUPERIOR),
+            GetString(SI_PA_QUALITY_EPIC),
+--            GetString(SI_PA_QUALITY_LEGENDARY),
+        },
         qualityLevel = {
             GetString(SI_PA_QUALITY_DISABLED),
             GetString(SI_PA_QUALITY_TRASH),
@@ -89,6 +97,14 @@ local PAMenuChoicesValues = {
         },
     },
     PAJunk = {
+        qualityLevelNoDisabled = {
+            ITEM_FUNCTIONAL_QUALITY_TRASH,         -- 0
+            ITEM_FUNCTIONAL_QUALITY_NORMAL,        -- 1
+            ITEM_FUNCTIONAL_QUALITY_MAGIC,         -- 2
+            ITEM_FUNCTIONAL_QUALITY_ARCANE,        -- 3
+            ITEM_FUNCTIONAL_QUALITY_ARTIFACT,      -- 4
+--            ITEM_FUNCTIONAL_QUALITY_LEGENDARY,     -- 5
+        },
         qualityLevel = {
             PAC.ITEM_QUALITY.DISABLED,  -- -1 (disabled)
             ITEM_FUNCTIONAL_QUALITY_TRASH,         -- 0

--- a/PersonalAssistant/Menu/MenuChoices.lua
+++ b/PersonalAssistant/Menu/MenuChoices.lua
@@ -56,12 +56,6 @@ local PAMenuChoices = {
             GetString(SI_PA_QUALITY_NORMAL),
             GetString(SI_PA_QUALITY_TRASH),
         },
-        itemAction = {
-            GetString(SI_PA_ITEM_ACTION_NOTHING),
-            GetString(SI_PA_ITEM_ACTION_MARK_AS_JUNK),
-            PAC.COLOR.ORANGE_RED:Colorize(GetString(SI_PA_ITEM_ACTION_JUNK_DESTROY_WORTHLESS)),
-            PAC.COLOR.RED:Colorize(GetString(SI_PA_ITEM_ACTION_DESTROY_ALWAYS)),
-        },
     },
     PARepair = {
         defaultSoulGem = {
@@ -122,12 +116,6 @@ local PAMenuChoicesValues = {
             ITEM_FUNCTIONAL_QUALITY_MAGIC,         -- 2
             ITEM_FUNCTIONAL_QUALITY_NORMAL,        -- 1
             ITEM_FUNCTIONAL_QUALITY_TRASH,         -- 0
-        },
-        itemAction = {
-            PAC.ITEM_ACTION.NOTHING,                -- 0
-            PAC.ITEM_ACTION.MARK_AS_JUNK,           -- 6
-            PAC.ITEM_ACTION.JUNK_DESTROY_WORTHLESS, -- 8
-            PAC.ITEM_ACTION.DESTROY_ALWAYS,         -- 9
         },
     },
     PARepair = {

--- a/PersonalAssistant/PersonalAssistantJunk/Menu/PAJunkMenu.lua
+++ b/PersonalAssistant/PersonalAssistantJunk/Menu/PAJunkMenu.lua
@@ -208,6 +208,37 @@ local function _createPAJunkMenu()
     })
 
     PAJunkOptionsTable:insert({
+        type = "slider",
+        name = GetString(SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_MAX_VALUE_THRESHOLD),
+        tooltip = GetString(SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_MAX_VALUE_THRESHOLD_T),
+        min = 0,
+        max = 99,
+        step = 1,
+        getFunc = PAJMenuFunctions.getDestroyMaxValueThresholdSetting,
+        setFunc = PAJMenuFunctions.setDestroyMaxValueThresholdSetting,
+        disabled = PAJMenuFunctions.isDestroyMaxValueThresholdDisabled,
+        default = PAJMenuDefaults.AutoDestroy.destroyMaxValueThreshold
+    })
+
+    PAJunkOptionsTable:insert({
+        type = "dropdown",
+        name = GetString(SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_MAX_QUALITY_THRESHOLD),
+        tooltip = GetString(SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_MAX_QUALITY_THRESHOLD_T),
+        choices = PAJMenuChoices.qualityLevelNoDisabled,
+        choicesValues = PAJMenuChoicesValues.qualityLevelNoDisabled,
+        getFunc = PAJMenuFunctions.getDestroyMaxQualityThresholdSetting,
+        setFunc = PAJMenuFunctions.setDestroyMaxQualityThresholdSetting,
+        disabled = PAJMenuFunctions.isDestroyMaxQualityThresholdDisabled,
+        default = PAJMenuDefaults.AutoDestroy.destroyMaxQualityThreshold,
+    })
+
+    PAJunkOptionsTable:insert({
+        type = "description",
+        text = GetString(SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_EXCLUSION_DISCLAIMER),
+        disabled = PAJMenuFunctions.isDestroyMaxQualityThresholdDisabled,
+    })
+
+    PAJunkOptionsTable:insert({
         type = "header",
         name = PAC.COLOR.YELLOW:Colorize(GetString(SI_PA_MENU_OTHER_SETTINGS_HEADER))
     })

--- a/PersonalAssistant/PersonalAssistantJunk/Menu/PAJunkMenu.lua
+++ b/PersonalAssistant/PersonalAssistantJunk/Menu/PAJunkMenu.lua
@@ -43,6 +43,9 @@ local PAJClockworkCityQuestsSubMenu = setmetatable({}, { __index = table })
 local PAJThievesGuildQuestsSubMenu = setmetatable({}, { __index = table })
 local PAJNewLifeFestivalSubMenu = setmetatable({}, { __index = table })
 
+local PAJDestroyJunkSubMenu = setmetatable({}, { __index = table })
+local PAJDestroyStolenJunkSubMenu = setmetatable({}, { __index = table })
+
 local PAJKeybindingsSubMenu = setmetatable({}, { __index = table })
 
 -- =================================================================================================================
@@ -139,6 +142,23 @@ local function _createPAJunkMenu()
 
     PAJunkOptionsTable:insert({
         type = "header",
+        name = PAC.COLOR.YELLOW:Colorize(GetString(SI_PA_MENU_JUNK_CUSTOM_ITEMS_HEADER))
+    })
+
+    PAJunkOptionsTable:insert({
+        type = "description",
+        text = GetString(SI_PA_MENU_JUNK_CUSTOM_ITEMS_DESCRIPTION)
+    })
+
+    PAJunkOptionsTable:insert({
+        type = "button",
+        name = GetString(SI_PA_MAINMENU_JUNK_HEADER),
+        func = PA.CustomDialogs.showPAJunkRulesMenu,
+        disabled = PAJProfileManager.isNoProfileSelected,
+    })
+
+    PAJunkOptionsTable:insert({
+        type = "header",
         name = PAC.COLOR.YELLOW:Colorize(GetString(SI_PA_MENU_JUNK_QUEST_ITEMS_HEADER))
     })
 
@@ -171,24 +191,31 @@ local function _createPAJunkMenu()
 
     PAJunkOptionsTable:insert({
         type = "header",
-        name = PAC.COLOR.YELLOW:Colorize(GetString(SI_PA_MENU_JUNK_CUSTOM_ITEMS_HEADER))
+        name = PAC.COLOR.YELLOW:Colorize(GetString(SI_PA_MENU_JUNK_AUTO_SELL_JUNK_HEADER))
     })
 
     PAJunkOptionsTable:insert({
-        type = "description",
-        text = GetString(SI_PA_MENU_JUNK_CUSTOM_ITEMS_DESCRIPTION)
+        type = "checkbox",
+        name = GetString(SI_PA_MENU_JUNK_AUTOSELL_JUNK),
+        getFunc = PAJMenuFunctions.getAutoSellJunkSetting,
+        setFunc = PAJMenuFunctions.setAutoSellJunkSetting,
+        disabled = PAJMenuFunctions.isAutoSellJunkDisabled,
+        default = PAJMenuDefaults.autoSellJunk,
     })
 
     PAJunkOptionsTable:insert({
-        type = "button",
-        name = GetString(SI_PA_MAINMENU_JUNK_HEADER),
-        func = PA.CustomDialogs.showPAJunkRulesMenu,
-        disabled = PAJProfileManager.isNoProfileSelected,
+        type = "checkbox",
+        name = GetString(SI_PA_MENU_JUNK_AUTOSELL_JUNK_PIRHARRI),
+        warning = GetString(SI_PA_MENU_JUNK_AUTOSELL_JUNK_PIRHARRI_W),
+        getFunc = PAJMenuFunctions.getAutoSellJunkPirharriSetting,
+        setFunc = PAJMenuFunctions.setAutoSellJunkPirharriSetting,
+        disabled = PAJMenuFunctions.isAutoSellJunkPirharriDisabled,
+        default = PAJMenuDefaults.autoSellJunkPirharri,
     })
 
     PAJunkOptionsTable:insert({
         type = "header",
-        name = PAC.COLOR.YELLOW:Colorize(GetString(SI_PA_MENU_JUNK_AUTO_DESTORY_JUNK_HEADER))
+        name = PAC.COLOR.YELLOW:Colorize(GetString(SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_HEADER))
     })
 
     PAJunkOptionsTable:insert({
@@ -197,45 +224,26 @@ local function _createPAJunkMenu()
     })
 
     PAJunkOptionsTable:insert({
-        type = "checkbox",
-        name = GetString(SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK),
-        tooltip = GetString(SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_T),
-        warning = GetString(SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_W),
-        getFunc = PAJMenuFunctions.getAutoDestroyWorthlessJunkSetting,
-        setFunc = PAJMenuFunctions.setAutoDestroyWorthlessJunkSetting,
-        disabled = PAJMenuFunctions.isAutoDestroyWorthlessJunkDisabled,
-        default = PAJMenuDefaults.AutoDestroy.destroyWorthlessJunk,
+        type = "submenu",
+        name = GetString(SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_JUNK_HEADER),
+        icon = PAC.ICONS.CRAFTBAG.JUNK.PATH,
+        iconTextureCoords = PAC.ICONS.TEXTURE_COORDS.MEDIUM,
+        controls = PAJDestroyJunkSubMenu,
+        disabledLabel = PAJMenuFunctions.isDestroyJunkMenuDisabled,
     })
 
     PAJunkOptionsTable:insert({
-        type = "slider",
-        name = GetString(SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_MAX_VALUE_THRESHOLD),
-        tooltip = GetString(SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_MAX_VALUE_THRESHOLD_T),
-        min = 0,
-        max = 99,
-        step = 1,
-        getFunc = PAJMenuFunctions.getDestroyMaxValueThresholdSetting,
-        setFunc = PAJMenuFunctions.setDestroyMaxValueThresholdSetting,
-        disabled = PAJMenuFunctions.isDestroyMaxValueThresholdDisabled,
-        default = PAJMenuDefaults.AutoDestroy.destroyMaxValueThreshold
-    })
-
-    PAJunkOptionsTable:insert({
-        type = "dropdown",
-        name = GetString(SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_MAX_QUALITY_THRESHOLD),
-        tooltip = GetString(SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_MAX_QUALITY_THRESHOLD_T),
-        choices = PAJMenuChoices.qualityLevelNoDisabled,
-        choicesValues = PAJMenuChoicesValues.qualityLevelNoDisabled,
-        getFunc = PAJMenuFunctions.getDestroyMaxQualityThresholdSetting,
-        setFunc = PAJMenuFunctions.setDestroyMaxQualityThresholdSetting,
-        disabled = PAJMenuFunctions.isDestroyMaxQualityThresholdDisabled,
-        default = PAJMenuDefaults.AutoDestroy.destroyMaxQualityThreshold,
+        type = "submenu",
+        name = GetString(SI_PA_MENU_JUNK_AUTO_DESTROY_STOLEN_JUNK_JUNK_HEADER),
+        icon = PAC.ICONS.ITEMS.STOLEN.PATH,
+        controls = PAJDestroyStolenJunkSubMenu,
+        disabledLabel = PAJMenuFunctions.isDestroyStolenJunkMenuDisabled,
     })
 
     PAJunkOptionsTable:insert({
         type = "description",
         text = GetString(SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_EXCLUSION_DISCLAIMER),
-        disabled = PAJMenuFunctions.isDestroyMaxQualityThresholdDisabled,
+        disabled = PAJMenuFunctions.isDestroyExclusionDisclaimerDisabled,
     })
 
     PAJunkOptionsTable:insert({
@@ -270,25 +278,6 @@ local function _createPAJunkMenu()
         setFunc = PAJMenuFunctions.setCraftedItemsIgnoredSetting,
         disabled = PAJMenuFunctions.isCraftedItemsIgnoredDisabled,
         default = PAJMenuDefaults.ignoreCraftedItems,
-    })
-
-    PAJunkOptionsTable:insert({
-        type = "checkbox",
-        name = GetString(SI_PA_MENU_JUNK_AUTOSELL_JUNK),
-        getFunc = PAJMenuFunctions.getAutoSellJunkSetting,
-        setFunc = PAJMenuFunctions.setAutoSellJunkSetting,
-        disabled = PAJMenuFunctions.isAutoSellJunkDisabled,
-        default = PAJMenuDefaults.autoSellJunk,
-    })
-
-    PAJunkOptionsTable:insert({
-        type = "checkbox",
-        name = GetString(SI_PA_MENU_JUNK_AUTOSELL_JUNK_PIRHARRI),
-        warning = GetString(SI_PA_MENU_JUNK_AUTOSELL_JUNK_PIRHARRI_W),
-        getFunc = PAJMenuFunctions.getAutoSellJunkPirharriSetting,
-        setFunc = PAJMenuFunctions.setAutoSellJunkPirharriSetting,
-        disabled = PAJMenuFunctions.isAutoSellJunkPirharriDisabled,
-        default = PAJMenuDefaults.autoSellJunkPirharri,
     })
 
     PAJunkOptionsTable:insert({
@@ -700,14 +689,12 @@ local function _createPAJStolenSubMenu()
     local _treasures = zo_strformat(GetString("SI_PA_ITEMTYPE", ITEMTYPE_TREASURE), 2)
 
     PAJStolenSubMenu:insert({
-        type = "dropdown",
+        type = "checkbox",
         name = PAHF.getFormattedKey(SI_PA_MENU_JUNK_ACTION_STOLEN_PLACEHOLDER, _trash),
-        choices = PAJMenuChoices.itemAction,
-        choicesValues = PAJMenuChoicesValues.itemAction,
-        getFunc = PAJMenuFunctions.getStolenTrashActionSetting,
-        setFunc = PAJMenuFunctions.setStolenTrashActionSetting,
-        disabled = PAJMenuFunctions.isStolenTrashActionDisabled,
-        default = PAJMenuDefaults.Stolen.trashAction,
+        getFunc = PAJMenuFunctions.getStolenTrashSetting,
+        setFunc = PAJMenuFunctions.setStolenTrashSetting,
+        disabled = PAJMenuFunctions.isStolenTrashDisabled,
+        default = PAJMenuDefaults.Stolen.trash,
     })
 
     PAJStolenSubMenu:insert({
@@ -716,36 +703,30 @@ local function _createPAJStolenSubMenu()
     })
 
     PAJStolenSubMenu:insert({
-        type = "dropdown",
+        type = "checkbox",
         name = PAHF.getFormattedKey(SI_PA_MENU_JUNK_ACTION_STOLEN_PLACEHOLDER, _weaponItemType),
-        choices = PAJMenuChoices.itemAction,
-        choicesValues = PAJMenuChoicesValues.itemAction,
-        getFunc = PAJMenuFunctions.getStolenWeaponActionSetting,
-        setFunc = PAJMenuFunctions.setStolenWeaponActionSetting,
-        disabled = PAJMenuFunctions.isStolenWeaponActionDisabled,
-        default = PAJMenuDefaults.Stolen.Weapons.action,
+        getFunc = PAJMenuFunctions.getStolenWeaponsSetting,
+        setFunc = PAJMenuFunctions.setStolenWeaponsSetting,
+        disabled = PAJMenuFunctions.isStolenWeaponsDisabled,
+        default = PAJMenuDefaults.Stolen.weapons,
     })
 
     PAJStolenSubMenu:insert({
-        type = "dropdown",
+        type = "checkbox",
         name = PAHF.getFormattedKey(SI_PA_MENU_JUNK_ACTION_STOLEN_PLACEHOLDER, _armorItemType),
-        choices = PAJMenuChoices.itemAction,
-        choicesValues = PAJMenuChoicesValues.itemAction,
-        getFunc = PAJMenuFunctions.getStolenArmorActionSetting,
-        setFunc = PAJMenuFunctions.setStolenArmorActionSetting,
-        disabled = PAJMenuFunctions.isStolenArmorActionDisabled,
-        default = PAJMenuDefaults.Stolen.Armor.action,
+        getFunc = PAJMenuFunctions.getStolenApparelsSetting,
+        setFunc = PAJMenuFunctions.setStolenApparelsSetting,
+        disabled = PAJMenuFunctions.isStolenApparelsDisabled,
+        default = PAJMenuDefaults.Stolen.apparels,
     })
 
     PAJStolenSubMenu:insert({
-        type = "dropdown",
+        type = "checkbox",
         name = PAHF.getFormattedKey(SI_PA_MENU_JUNK_ACTION_STOLEN_PLACEHOLDER, _jewelryItemType),
-        choices = PAJMenuChoices.itemAction,
-        choicesValues = PAJMenuChoicesValues.itemAction,
-        getFunc = PAJMenuFunctions.getStolenJewelryActionSetting,
-        setFunc = PAJMenuFunctions.setStolenJewelryActionSetting,
-        disabled = PAJMenuFunctions.isStolenJewelryActionDisabled,
-        default = PAJMenuDefaults.Stolen.Jewelry.action,
+        getFunc = PAJMenuFunctions.getStolenJewelriesSetting,
+        setFunc = PAJMenuFunctions.setStolenJewelriesSetting,
+        disabled = PAJMenuFunctions.isStolenJewelriesDisabled,
+        default = PAJMenuDefaults.Stolen.jewelries,
     })
 
     PAJStolenSubMenu:insert({
@@ -754,25 +735,21 @@ local function _createPAJStolenSubMenu()
     })
 
     PAJStolenSubMenu:insert({
-        type = "dropdown",
+        type = "checkbox",
         name = PAHF.getFormattedKey(SI_PA_MENU_JUNK_ACTION_STOLEN_PLACEHOLDER, _styleMaterials),
-        choices = PAJMenuChoices.itemAction,
-        choicesValues = PAJMenuChoicesValues.itemAction,
-        getFunc = PAJMenuFunctions.getStolenStyleMaterialActionSetting,
-        setFunc = PAJMenuFunctions.setStolenStyleMaterialActionSetting,
-        disabled = PAJMenuFunctions.isStolenStyleMaterialActionDisabled,
-        default = PAJMenuDefaults.Stolen.styleMaterialAction,
+        getFunc = PAJMenuFunctions.getStolenStyleMaterialsSetting,
+        setFunc = PAJMenuFunctions.setStolenStyleMaterialsSetting,
+        disabled = PAJMenuFunctions.isStolenStyleMaterialsDisabled,
+        default = PAJMenuDefaults.Stolen.styleMaterials,
     })
 
     PAJStolenSubMenu:insert({
-        type = "dropdown",
+        type = "checkbox",
         name = PAHF.getFormattedKey(SI_PA_MENU_JUNK_ACTION_STOLEN_PLACEHOLDER, _traitItems),
-        choices = PAJMenuChoices.itemAction,
-        choicesValues = PAJMenuChoicesValues.itemAction,
-        getFunc = PAJMenuFunctions.getStolenTraitItemActionSetting,
-        setFunc = PAJMenuFunctions.setStolenTraitItemActionSetting,
-        disabled = PAJMenuFunctions.isStolenTraitItemActionDisabled,
-        default = PAJMenuDefaults.Stolen.traitItemAction,
+        getFunc = PAJMenuFunctions.getStolenTraitItemsSetting,
+        setFunc = PAJMenuFunctions.setStolenTraitItemsSetting,
+        disabled = PAJMenuFunctions.isStolenTraitItemsDisabled,
+        default = PAJMenuDefaults.Stolen.traitItems,
     })
 
     PAJStolenSubMenu:insert({
@@ -781,47 +758,39 @@ local function _createPAJStolenSubMenu()
     })
 
     PAJStolenSubMenu:insert({
-        type = "dropdown",
+        type = "checkbox",
         name = PAHF.getFormattedKey(SI_PA_MENU_JUNK_ACTION_STOLEN_PLACEHOLDER, _lures),
-        choices = PAJMenuChoices.itemAction,
-        choicesValues = PAJMenuChoicesValues.itemAction,
-        getFunc = PAJMenuFunctions.getStolenLureActionSetting,
-        setFunc = PAJMenuFunctions.setStolenLureActionSetting,
-        disabled = PAJMenuFunctions.isStolenLureActionDisabled,
-        default = PAJMenuDefaults.Stolen.lureAction,
+        getFunc = PAJMenuFunctions.getStolenLuresSetting,
+        setFunc = PAJMenuFunctions.setStolenLuresSetting,
+        disabled = PAJMenuFunctions.isStolenLuresDisabled,
+        default = PAJMenuDefaults.Stolen.lures,
     })
 
     PAJStolenSubMenu:insert({
-        type = "dropdown",
+        type = "checkbox",
         name = PAHF.getFormattedKey(SI_PA_MENU_JUNK_ACTION_STOLEN_PLACEHOLDER, _ingredients),
-        choices = PAJMenuChoices.itemAction,
-        choicesValues = PAJMenuChoicesValues.itemAction,
-        getFunc = PAJMenuFunctions.getStolenIngredientActionSetting,
-        setFunc = PAJMenuFunctions.setStolenIngredientActionSetting,
-        disabled = PAJMenuFunctions.isStolenIngredientActionDisabled,
-        default = PAJMenuDefaults.Stolen.ingredientAction,
+        getFunc = PAJMenuFunctions.getStolenIngredientsSetting,
+        setFunc = PAJMenuFunctions.setStolenIngredientsSetting,
+        disabled = PAJMenuFunctions.isStolenIngredientsDisabled,
+        default = PAJMenuDefaults.Stolen.ingredients,
     })
 
     PAJStolenSubMenu:insert({
-        type = "dropdown",
+        type = "checkbox",
         name = PAHF.getFormattedKey(SI_PA_MENU_JUNK_ACTION_STOLEN_PLACEHOLDER, _foods),
-        choices = PAJMenuChoices.itemAction,
-        choicesValues = PAJMenuChoicesValues.itemAction,
-        getFunc = PAJMenuFunctions.getStolenFoodActionSetting,
-        setFunc = PAJMenuFunctions.setStolenFoodActionSetting,
-        disabled = PAJMenuFunctions.isStolenFoodActionDisabled,
-        default = PAJMenuDefaults.Stolen.foodAction,
+        getFunc = PAJMenuFunctions.getStolenFoodSetting,
+        setFunc = PAJMenuFunctions.setStolenFoodSetting,
+        disabled = PAJMenuFunctions.isStolenFoodDisabled,
+        default = PAJMenuDefaults.Stolen.food,
     })
 
     PAJStolenSubMenu:insert({
-        type = "dropdown",
+        type = "checkbox",
         name = PAHF.getFormattedKey(SI_PA_MENU_JUNK_ACTION_STOLEN_PLACEHOLDER, _drinks),
-        choices = PAJMenuChoices.itemAction,
-        choicesValues = PAJMenuChoicesValues.itemAction,
-        getFunc = PAJMenuFunctions.getStolenDrinkActionSetting,
-        setFunc = PAJMenuFunctions.setStolenDrinkActionSetting,
-        disabled = PAJMenuFunctions.isStolenDrinkActionDisabled,
-        default = PAJMenuDefaults.Stolen.drinkAction,
+        getFunc = PAJMenuFunctions.getStolenDrinksSetting,
+        setFunc = PAJMenuFunctions.setStolenDrinksSetting,
+        disabled = PAJMenuFunctions.isStolenDrinksDisabled,
+        default = PAJMenuDefaults.Stolen.drinks,
     })
 
     PAJStolenSubMenu:insert({
@@ -830,14 +799,12 @@ local function _createPAJStolenSubMenu()
     })
 
     PAJStolenSubMenu:insert({
-        type = "dropdown",
+        type = "checkbox",
         name = PAHF.getFormattedKey(SI_PA_MENU_JUNK_ACTION_STOLEN_PLACEHOLDER, _solvents),
-        choices = PAJMenuChoices.itemAction,
-        choicesValues = PAJMenuChoicesValues.itemAction,
-        getFunc = PAJMenuFunctions.getStolenSolventActionSetting,
-        setFunc = PAJMenuFunctions.setStolenSolventActionSetting,
-        disabled = PAJMenuFunctions.isStolenSolventActionDisabled,
-        default = PAJMenuDefaults.Stolen.solventAction,
+        getFunc = PAJMenuFunctions.getStolenSolventsSetting,
+        setFunc = PAJMenuFunctions.setStolenSolventsSetting,
+        disabled = PAJMenuFunctions.isStolenSolventsDisabled,
+        default = PAJMenuDefaults.Stolen.solvents,
     })
 
     PAJStolenSubMenu:insert({
@@ -846,14 +813,12 @@ local function _createPAJStolenSubMenu()
     })
 
     PAJStolenSubMenu:insert({
-        type = "dropdown",
+        type = "checkbox",
         name = PAHF.getFormattedKey(SI_PA_MENU_JUNK_ACTION_STOLEN_PLACEHOLDER, _treasures),
-        choices = PAJMenuChoices.itemAction,
-        choicesValues = PAJMenuChoicesValues.itemAction,
-        getFunc = PAJMenuFunctions.getStolenTreasureActionSetting,
-        setFunc = PAJMenuFunctions.setStolenTreasureActionSetting,
-        disabled = PAJMenuFunctions.isStolenTreasureActionDisabled,
-        default = PAJMenuDefaults.Stolen.treasureAction,
+        getFunc = PAJMenuFunctions.getStolenTreasuresSetting,
+        setFunc = PAJMenuFunctions.setStolenTreasuresSetting,
+        disabled = PAJMenuFunctions.isStolenTreasuresDisabled,
+        default = PAJMenuDefaults.Stolen.treasures,
     })
 end
 
@@ -863,7 +828,7 @@ local function _createPAJClockworkCityQuestsSubMenu()
     PAJClockworkCityQuestsSubMenu:insert({
         type = "description",
         text = GetString(SI_PA_MENU_JUNK_TRASH_EXCLUDE_ITEMS_DESC),
-        disabled = PAJMenuFunctions.isExcludeNibblesAndBitsDisabled,
+        disabled = PAJMenuFunctions.isExcludeTrashDescriptionDisabled,
     })
 
     PAJClockworkCityQuestsSubMenu:insert({
@@ -894,7 +859,7 @@ local function _createPAJClockworkCityQuestsSubMenu()
     PAJClockworkCityQuestsSubMenu:insert({
         type = "description",
         text = GetString(SI_PA_MENU_JUNK_MISCELLANEOUS_TREASURES_EXCLUDE_ITEMS_DESC),
-        disabled = PAJMenuFunctions.isExcludeAMatterOfLeisureDisabled,
+        disabled = PAJMenuFunctions.isExcludeTreasuresDescriptionDisabled,
     })
 
     PAJClockworkCityQuestsSubMenu:insert({
@@ -934,7 +899,7 @@ local function _createPAJThievesGuildQuestsSubMenu()
     PAJThievesGuildQuestsSubMenu:insert({
         type = "description",
         text = GetString(SI_PA_MENU_JUNK_MISCELLANEOUS_TREASURES_EXCLUDE_ITEMS_DESC),
-        disabled = PAJMenuFunctions.isNewLifeFestivalMenuDisabled,
+        disabled = PAJMenuFunctions.isThievesGuildMenuDisabled,
     })
 
     PAJThievesGuildQuestsSubMenu:insert({
@@ -965,6 +930,86 @@ local function _createPAJNewLifeFestivalSubMenu()
         setFunc = PAJMenuFunctions.setExcludeRareFishSetting,
         disabled = PAJMenuFunctions.isExcludeRareFishDisabled,
         default = PAJMenuDefaults.QuestProtection.NewLifeFestival.excludeRareFish,
+    })
+end
+
+-- -----------------------------------------------------------------------------------------------------------------
+
+local function _createPAJDestroyJunkSubMenu()
+    PAJDestroyJunkSubMenu:insert({
+        type = "checkbox",
+        name = GetString(SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK),
+        tooltip = GetString(SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_T),
+        warning = GetString(SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_W),
+        getFunc = PAJMenuFunctions.getAutoDestroyJunkSetting,
+        setFunc = PAJMenuFunctions.setAutoDestroyJunkSetting,
+        disabled = PAJMenuFunctions.isAutoDestroyJunkDisabled,
+        default = PAJMenuDefaults.AutoDestroy.destroyJunk,
+    })
+
+    PAJDestroyJunkSubMenu:insert({
+        type = "slider",
+        name = GetString(SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_MAX_VALUE_THRESHOLD),
+        tooltip = GetString(SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_MAX_VALUE_THRESHOLD_T),
+        min = 0,
+        max = 100,
+        step = 1,
+        getFunc = PAJMenuFunctions.getDestroyMaxValueThresholdSetting,
+        setFunc = PAJMenuFunctions.setDestroyMaxValueThresholdSetting,
+        disabled = PAJMenuFunctions.isDestroyMaxValueThresholdDisabled,
+        default = PAJMenuDefaults.AutoDestroy.destroyMaxValueThreshold
+    })
+
+    PAJDestroyJunkSubMenu:insert({
+        type = "dropdown",
+        name = GetString(SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_MAX_QUALITY_THRESHOLD),
+        tooltip = GetString(SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_MAX_QUALITY_THRESHOLD_T),
+        choices = PAJMenuChoices.qualityLevelNoDisabled,
+        choicesValues = PAJMenuChoicesValues.qualityLevelNoDisabled,
+        getFunc = PAJMenuFunctions.getDestroyMaxQualityThresholdSetting,
+        setFunc = PAJMenuFunctions.setDestroyMaxQualityThresholdSetting,
+        disabled = PAJMenuFunctions.isDestroyMaxQualityThresholdDisabled,
+        default = PAJMenuDefaults.AutoDestroy.destroyMaxQualityThreshold,
+    })
+end
+
+-- -----------------------------------------------------------------------------------------------------------------
+
+local function _createPAJDestroyStolenJunkSubMenu()
+    PAJDestroyStolenJunkSubMenu:insert({
+        type = "checkbox",
+        name = GetString(SI_PA_MENU_JUNK_AUTO_DESTROY_STOLEN_JUNK),
+        tooltip = GetString(SI_PA_MENU_JUNK_AUTO_DESTROY_STOLEN_JUNK_T),
+        warning = GetString(SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_W),
+        getFunc = PAJMenuFunctions.getAutoDestroyStolenJunkSetting,
+        setFunc = PAJMenuFunctions.setAutoDestroyStolenJunkSetting,
+        disabled = PAJMenuFunctions.isAutoDestroyStolenJunkDisabled,
+        default = PAJMenuDefaults.AutoDestroy.destroyStolenJunk,
+    })
+
+    PAJDestroyStolenJunkSubMenu:insert({
+        type = "slider",
+        name = GetString(SI_PA_MENU_JUNK_AUTO_DESTROY_STOLEN_JUNK_MAX_VALUE_THRESHOLD),
+        tooltip = GetString(SI_PA_MENU_JUNK_AUTO_DESTROY_STOLEN_JUNK_MAX_VALUE_THRESHOLD_T),
+        min = 0,
+        max = 100,
+        step = 1,
+        getFunc = PAJMenuFunctions.getDestroyMaxStolenValueThresholdSetting,
+        setFunc = PAJMenuFunctions.setDestroyMaxStolenValueThresholdSetting,
+        disabled = PAJMenuFunctions.isDestroyMaxStolenValueThresholdDisabled,
+        default = PAJMenuDefaults.AutoDestroy.destroyMaxStolenValueThreshold
+    })
+
+    PAJDestroyStolenJunkSubMenu:insert({
+        type = "dropdown",
+        name = GetString(SI_PA_MENU_JUNK_AUTO_DESTROY_STOLEN_JUNK_MAX_QUALITY_THRESHOLD),
+        tooltip = GetString(SI_PA_MENU_JUNK_AUTO_DESTROY_STOLEN_JUNK_MAX_QUALITY_THRESHOLD_T),
+        choices = PAJMenuChoices.qualityLevelNoDisabled,
+        choicesValues = PAJMenuChoicesValues.qualityLevelNoDisabled,
+        getFunc = PAJMenuFunctions.getDestroyMaxStolenQualityThresholdSetting,
+        setFunc = PAJMenuFunctions.setDestroyMaxStolenQualityThresholdSetting,
+        disabled = PAJMenuFunctions.isDestroyMaxStolenQualityThresholdDisabled,
+        default = PAJMenuDefaults.AutoDestroy.destroyMaxStolenQualityThreshold,
     })
 end
 
@@ -1077,6 +1122,9 @@ local function createOptions()
     _createPAJClockworkCityQuestsSubMenu()
     _createPAJThievesGuildQuestsSubMenu()
     _createPAJNewLifeFestivalSubMenu()
+
+    _createPAJDestroyJunkSubMenu()
+    _createPAJDestroyStolenJunkSubMenu()
 
     _createPAJKeybindingsSubMenu()
 

--- a/PersonalAssistant/PersonalAssistantJunk/Menu/PAJunkMenuDefaults.lua
+++ b/PersonalAssistant/PersonalAssistantJunk/Menu/PAJunkMenuDefaults.lua
@@ -70,7 +70,9 @@ local PAJunkMenuDefaults = {
         }
     },
     AutoDestroy = {
-        destroyWorthlessJunk = false
+        destroyWorthlessJunk = false,
+        destroyMaxValueThreshold = 0,
+        destroyMaxQualityThreshold = ITEM_FUNCTIONAL_QUALITY_TRASH,
     },
     QuestProtection = {
         ClockworkCity = {

--- a/PersonalAssistant/PersonalAssistantJunk/Menu/PAJunkMenuDefaults.lua
+++ b/PersonalAssistant/PersonalAssistantJunk/Menu/PAJunkMenuDefaults.lua
@@ -45,24 +45,18 @@ local PAJunkMenuDefaults = {
         autoMarkUnknownTraits = false,
     },
     Stolen = {
-        Weapons = {
-            action = PAC.ITEM_ACTION.NOTHING,
-        },
-        Armor = {
-            action = PAC.ITEM_ACTION.NOTHING,
-        },
-        Jewelry = {
-            action = PAC.ITEM_ACTION.NOTHING,
-        },
-        trashAction = PAC.ITEM_ACTION.NOTHING,
-        styleMaterialAction = PAC.ITEM_ACTION.NOTHING,
-        traitItemAction = PAC.ITEM_ACTION.NOTHING,
-        lureAction = PAC.ITEM_ACTION.NOTHING,
-        ingredientAction = PAC.ITEM_ACTION.NOTHING,
-        foodAction = PAC.ITEM_ACTION.NOTHING,
-        drinkAction = PAC.ITEM_ACTION.NOTHING,
-        solventAction = PAC.ITEM_ACTION.NOTHING,
-        treasureAction = PAC.ITEM_ACTION.NOTHING,
+        trash = false,
+        weapons = false,
+        apparels = false,
+        jewelries = false,
+        styleMaterials = false,
+        traitItems = false,
+        lures = false,
+        ingredients = false,
+        food = false,
+        drinks = false,
+        solvents = false,
+        treasures = false,
     },
     Custom = {
         customItemsEnabled = true,
@@ -70,9 +64,13 @@ local PAJunkMenuDefaults = {
         }
     },
     AutoDestroy = {
-        destroyWorthlessJunk = false,
+        destroyJunk = false,
         destroyMaxValueThreshold = 0,
         destroyMaxQualityThreshold = ITEM_FUNCTIONAL_QUALITY_TRASH,
+
+        destroyStolenJunk = false,
+        destroyMaxStolenValueThreshold = 0,
+        destroyMaxStolenQualityThreshold = ITEM_FUNCTIONAL_QUALITY_TRASH,
     },
     QuestProtection = {
         ClockworkCity = {

--- a/PersonalAssistant/PersonalAssistantJunk/Menu/PAJunkMenuFunctions.lua
+++ b/PersonalAssistant/PersonalAssistantJunk/Menu/PAJunkMenuFunctions.lua
@@ -119,25 +119,22 @@ end
 -- PAJunk   QuestProtection         ClockworkCity
 ---------------------------------
 local function isPAJunkClockworkCityMenuDisabled()
-    if isDisabled({"autoMarkAsJunkEnabled"}) then return true end
-    if (isDisabled({"Trash", "autoMarkTrash"}) or isDisabledAll({"QuestProtection", "ClockworkCity", "excludeNibblesAndBits"}, {"QuestProtection", "ClockworkCity", "excludeMorselsAndPecks"})) and
-            ((isDisabled({"Miscellaneous", "autoMarkTreasure"}) and tonumber(getValue({"Stolen", "treasureAction"})) == PAC.ITEM_ACTION.NOTHING) or isDisabledAll({"QuestProtection", "ClockworkCity", "excludeAMatterOfLeisure"}, {"QuestProtection", "ClockworkCity", "excludeAMatterOfRespect"}, {"QuestProtection", "ClockworkCity", "excludeAMatterOfTributes"})) then
-        return true
-    end
-    -- if no 'true' returned so far, return false now
-    return false
+    return (isDisabledAll({"QuestProtection", "ClockworkCity", "excludeNibblesAndBits"}, {"QuestProtection", "ClockworkCity", "excludeMorselsAndPecks"})) and
+            (isDisabledAll({"QuestProtection", "ClockworkCity", "excludeAMatterOfLeisure"}, {"QuestProtection", "ClockworkCity", "excludeAMatterOfRespect"}, {"QuestProtection", "ClockworkCity", "excludeAMatterOfTributes"}))
+end
+
+--------------------------------------------------------------------------
+-- PAJunk   QuestProtection.ClockworkCity         excludeNibblesAndBits/excludeMorselsAndPecks
+---------------------------------
+local function isPAJunkExcludeTrashDescriptionDisabled()
+    return isDisabledAll({"QuestProtection", "ClockworkCity", "excludeNibblesAndBits"}, {"QuestProtection", "ClockworkCity", "excludeMorselsAndPecks"})
 end
 
 --------------------------------------------------------------------------
 -- PAJunk   QuestProtection.ClockworkCity         excludeAMatterOfLeisure/excludeAMatterOfRespect/excludeAMatterOfTributes
 ---------------------------------
-local function isPAJunkExcludeAMatterOfXYZDisabled()
-    if isDisabled({"autoMarkAsJunkEnabled"}) then return true end
-    if isDisabled({"Miscellaneous", "autoMarkTreasure"}) then
-        if tonumber(getValue({"Stolen", "treasureAction"})) == PAC.ITEM_ACTION.NOTHING then return true end
-    end
-    -- if no 'true' returned so far, return false now
-    return false
+local function isPAJunkExcludeTreasuresDescriptionDisabled()
+    return isDisabledAll({"QuestProtection", "ClockworkCity", "excludeAMatterOfLeisure"}, {"QuestProtection", "ClockworkCity", "excludeAMatterOfRespect"}, {"QuestProtection", "ClockworkCity", "excludeAMatterOfTributes"})
 end
 
 --------------------------------------------------------------------------
@@ -145,7 +142,7 @@ end
 ---------------------------------
 local function isPAJunkThievesGuildMenuDisabled()
     if isDisabled({"autoMarkAsJunkEnabled"}) then return true end
-    if ((isDisabled({"Miscellaneous", "autoMarkTreasure"}) and tonumber(getValue({"Stolen", "treasureAction"})) == PAC.ITEM_ACTION.NOTHING) or isDisabledAll({"QuestProtection", "ThievesGuild", "excludeTheCovetousCountess"})) then
+    if ((isDisabled({"Miscellaneous", "autoMarkTreasure"}) and getValue({"Stolen", "treasureAction"})) or isDisabledAll({"QuestProtection", "ThievesGuild", "excludeTheCovetousCountess"})) then
         return true
     end
     -- if no 'true' returned so far, return false now
@@ -181,32 +178,34 @@ end
 ---------------------------------
 local function isPAJunkStolenMenuDisabled()
     if isDisabled({"autoMarkAsJunkEnabled"}) then return true end
-    if not (tonumber(getValue({"Stolen", "trashAction"})) == PAC.ITEM_ACTION.NOTHING) then return false end
-    if not (tonumber(getValue({"Stolen", "styleMaterialAction"})) == PAC.ITEM_ACTION.NOTHING) then return false end
-    if not (tonumber(getValue({"Stolen", "traitItemAction"})) == PAC.ITEM_ACTION.NOTHING) then return false end
-    if not (tonumber(getValue({"Stolen", "lureAction"})) == PAC.ITEM_ACTION.NOTHING) then return false end
-    if not (tonumber(getValue({"Stolen", "ingredientAction"})) == PAC.ITEM_ACTION.NOTHING) then return false end
-    if not (tonumber(getValue({"Stolen", "foodAction"})) == PAC.ITEM_ACTION.NOTHING) then return false end
-    if not (tonumber(getValue({"Stolen", "drinkAction"})) == PAC.ITEM_ACTION.NOTHING) then return false end
-    if not (tonumber(getValue({"Stolen", "solventAction"})) == PAC.ITEM_ACTION.NOTHING) then return false end
-    if not (tonumber(getValue({"Stolen", "treasureAction"})) == PAC.ITEM_ACTION.NOTHING) then return false end
-    if not (tonumber(getValue({"Stolen", "Weapons", "action"})) == PAC.ITEM_ACTION.NOTHING) then return false end
-    if not (tonumber(getValue({"Stolen", "Armor", "action"})) == PAC.ITEM_ACTION.NOTHING) then return false end
-    if not (tonumber(getValue({"Stolen", "Jewelry", "action"})) == PAC.ITEM_ACTION.NOTHING) then return false end
-    -- if no 'false' returned so far, return true now
-    return true
+    return isDisabledAll({"Stolen", "trash"}, {"Stolen", "weapons"}, {"Stolen", "apparels"}, {"Stolen", "jewelries"},
+                         {"Stolen", "styleMaterials"}, {"Stolen", "traitItems"}, {"Stolen", "lures"}, {"Stolen", "ingredients"},
+                         {"Stolen", "food"}, {"Stolen", "drinks"}, {"Stolen", "solvents"}, {"Stolen", "treasures"})
 end
 
 --------------------------------------------------------------------------
--- PAJunk   AutoDestroy     destroyWorthlessJunk
+-- PAJunk   AutoDestroy     destroyJunk
 ---------------------------------
-local function setPAJunkAutoDestroyWorthlessJunkSetting(value)
+local function setPAJunkAutoDestroyJunkSetting(value)
     if isNoProfileSelected() then return end
-    setValue(value, {"AutoDestroy", "destroyWorthlessJunk"})
+    setValue(value, {"AutoDestroy", "destroyJunk"})
     if tostring(value) == "true" then
-        PAJ.println(SI_PA_CHAT_JUNK_DESTROY_WORTHLESS_ON)
+        PAJ.println(SI_PA_CHAT_JUNK_DESTROY_ON)
     else
-        PAJ.println(SI_PA_CHAT_JUNK_DESTROY_WORTHLESS_OFF)
+        PAJ.println(SI_PA_CHAT_JUNK_DESTROY_OFF)
+    end
+end
+
+--------------------------------------------------------------------------
+-- PAJunk   AutoDestroy     destroyStolenJunk
+---------------------------------
+local function setPAJunkAutoDestroyStolenJunkSetting(value)
+    if isNoProfileSelected() then return end
+    setValue(value, {"AutoDestroy", "destroyStolenJunk"})
+    if tostring(value) == "true" then
+        PAJ.println(SI_PA_CHAT_JUNK_DESTROY_STOLEN_ON)
+    else
+        PAJ.println(SI_PA_CHAT_JUNK_DESTROY_STOLEN_OFF)
     end
 end
 
@@ -299,24 +298,27 @@ local PAJunkMenuFunctions = {
     setJewelryIncludeUnknownTraitsSetting = function(value) setValue(value, {"Jewelry", "autoMarkUnknownTraits"}) end,
 
     isClockworkCityMenuDisabled = isPAJunkClockworkCityMenuDisabled,
-    isExcludeNibblesAndBitsDisabled = function() return isDisabled({"autoMarkAsJunkEnabled"}, {"Trash", "autoMarkTrash"}) end,
+    isExcludeTrashDescriptionDisabled = isPAJunkExcludeTrashDescriptionDisabled,
+    isExcludeNibblesAndBitsDisabled = function() return isDisabled() end, -- currently always enabled (due to potential custom rules)
     getExcludeNibblesAndBitsSetting = function() return getValue({"QuestProtection", "ClockworkCity", "excludeNibblesAndBits"}) end,
     setExcludeNibblesAndBitsSetting = function(value) setValue(value, {"QuestProtection", "ClockworkCity", "excludeNibblesAndBits"}) end,
-    isExcludeMorselsAndPecksDisabled = function() return isDisabled({"autoMarkAsJunkEnabled"}, {"Trash", "autoMarkTrash"}) end,
+    isExcludeMorselsAndPecksDisabled = function() return isDisabled() end, -- currently always enabled (due to potential custom rules)
     getExcludeMorselsAndPecksSetting = function() return getValue({"QuestProtection", "ClockworkCity", "excludeMorselsAndPecks"}) end,
     setExcludeMorselsAndPecksSetting = function(value) setValue(value, {"QuestProtection", "ClockworkCity", "excludeMorselsAndPecks"}) end,
-    isExcludeAMatterOfLeisureDisabled = isPAJunkExcludeAMatterOfXYZDisabled,
+
+    isExcludeTreasuresDescriptionDisabled = isPAJunkExcludeTreasuresDescriptionDisabled, -- TODO: check stolen treasures
+    isExcludeAMatterOfLeisureDisabled = function() return isDisabled() end, -- currently always enabled (due to potential custom rules)
     getExcludeAMatterOfLeisureSetting = function() return getValue({"QuestProtection", "ClockworkCity", "excludeAMatterOfLeisure"}) end,
     setExcludeAMatterOfLeisureSetting = function(value) setValue(value, {"QuestProtection", "ClockworkCity", "excludeAMatterOfLeisure"}) end,
-    isExcludeAMatterOfRespectDisabled = isPAJunkExcludeAMatterOfXYZDisabled,
+    isExcludeAMatterOfRespectDisabled = function() return isDisabled() end, -- currently always enabled (due to potential custom rules)
     getExcludeAMatterOfRespectSetting = function() return getValue({"QuestProtection", "ClockworkCity", "excludeAMatterOfRespect"}) end,
     setExcludeAMatterOfRespectSetting = function(value) setValue(value, {"QuestProtection", "ClockworkCity", "excludeAMatterOfRespect"}) end,
-    isExcludeAMatterOfTributesDisabled = isPAJunkExcludeAMatterOfXYZDisabled,
+    isExcludeAMatterOfTributesDisabled = function() return isDisabled() end, -- currently always enabled (due to potential custom rules)
     getExcludeAMatterOfTributesSetting = function() return getValue({"QuestProtection", "ClockworkCity", "excludeAMatterOfTributes"}) end,
     setExcludeAMatterOfTributesSetting = function(value) setValue(value, {"QuestProtection", "ClockworkCity", "excludeAMatterOfTributes"}) end,
 
     isThievesGuildMenuDisabled = isPAJunkThievesGuildMenuDisabled,
-    isExcludeTheCovetousCountessDisabled = isPAJunkExcludeAMatterOfXYZDisabled,
+    isExcludeTheCovetousCountessDisabled = function() return isDisabled() end, -- currently always enabled (due to potential custom rules)
     getExcludeTheCovetousCountessSetting = function() return getValue({"QuestProtection", "ThievesGuild", "excludeTheCovetousCountess"}) end,
     setExcludeTheCovetousCountessSetting = function(value) setValue(value, {"QuestProtection", "ThievesGuild", "excludeTheCovetousCountess"}) end,
 
@@ -326,55 +328,69 @@ local PAJunkMenuFunctions = {
     setExcludeRareFishSetting = function(value) setValue(value, {"QuestProtection", "NewLifeFestival", "excludeRareFish"}) end,
 
     isStolenMenuDisabled = isPAJunkStolenMenuDisabled,
-    isStolenWeaponActionDisabled = function() return isDisabled({"autoMarkAsJunkEnabled"}) end,
-    getStolenWeaponActionSetting = function() return getValue({"Stolen", "Weapons", "action"}) end,
-    setStolenWeaponActionSetting = function(value) setValue(value, {"Stolen", "Weapons", "action"}) end,
-    isStolenArmorActionDisabled = function() return isDisabled({"autoMarkAsJunkEnabled"}) end,
-    getStolenArmorActionSetting = function() return getValue({"Stolen", "Armor", "action"}) end,
-    setStolenArmorActionSetting = function(value) setValue(value, {"Stolen", "Armor", "action"}) end,
-    isStolenJewelryActionDisabled = function() return isDisabled({"autoMarkAsJunkEnabled"}) end,
-    getStolenJewelryActionSetting = function() return getValue({"Stolen", "Jewelry", "action"}) end,
-    setStolenJewelryActionSetting = function(value) setValue(value, {"Stolen", "Jewelry", "action"}) end,
-    isStolenTrashActionDisabled = function() return isDisabled({"autoMarkAsJunkEnabled"}) end,
-    getStolenTrashActionSetting = function() return getValue({"Stolen", "trashAction"}) end,
-    setStolenTrashActionSetting = function(value) setValue(value, {"Stolen", "trashAction"}) end,
-    isStolenStyleMaterialActionDisabled = function() return isDisabled({"autoMarkAsJunkEnabled"}) end,
-    getStolenStyleMaterialActionSetting = function() return getValue({"Stolen", "styleMaterialAction"}) end,
-    setStolenStyleMaterialActionSetting = function(value) setValue(value, {"Stolen", "styleMaterialAction"}) end,
-    isStolenTraitItemActionDisabled = function() return isDisabled({"autoMarkAsJunkEnabled"}) end,
-    getStolenTraitItemActionSetting = function() return getValue({"Stolen", "traitItemAction"}) end,
-    setStolenTraitItemActionSetting = function(value) setValue(value, {"Stolen", "traitItemAction"}) end,
-    isStolenLureActionDisabled = function() return isDisabled({"autoMarkAsJunkEnabled"}) end,
-    getStolenLureActionSetting = function() return getValue({"Stolen", "lureAction"}) end,
-    setStolenLureActionSetting = function(value) setValue(value, {"Stolen", "lureAction"}) end,
-    isStolenIngredientActionDisabled = function() return isDisabled({"autoMarkAsJunkEnabled"}) end,
-    getStolenIngredientActionSetting = function() return getValue({"Stolen", "ingredientAction"}) end,
-    setStolenIngredientActionSetting = function(value) setValue(value, {"Stolen", "ingredientAction"}) end,
-    isStolenFoodActionDisabled = function() return isDisabled({"autoMarkAsJunkEnabled"}) end,
-    getStolenFoodActionSetting = function() return getValue({"Stolen", "foodAction"}) end,
-    setStolenFoodActionSetting = function(value) setValue(value, {"Stolen", "foodAction"}) end,
-    isStolenDrinkActionDisabled = function() return isDisabled({"autoMarkAsJunkEnabled"}) end,
-    getStolenDrinkActionSetting = function() return getValue({"Stolen", "drinkAction"}) end,
-    setStolenDrinkActionSetting = function(value) setValue(value, {"Stolen", "drinkAction"}) end,
-    isStolenSolventActionDisabled = function() return isDisabled({"autoMarkAsJunkEnabled"}) end,
-    getStolenSolventActionSetting = function() return getValue({"Stolen", "solventAction"}) end,
-    setStolenSolventActionSetting = function(value) setValue(value, {"Stolen", "solventAction"}) end,
-    isStolenTreasureActionDisabled = function() return isDisabled({"autoMarkAsJunkEnabled"}) end,
-    getStolenTreasureActionSetting = function() return getValue({"Stolen", "treasureAction"}) end,
-    setStolenTreasureActionSetting = function(value) setValue(value, {"Stolen", "treasureAction"}) end,
+    isStolenTrashDisabled = function() return isDisabled({"autoMarkAsJunkEnabled"}) end,
+    getStolenTrashSetting = function() return getValue({"Stolen", "trash"}) end,
+    setStolenTrashSetting = function(value) setValue(value, {"Stolen", "trash"}) end,
+    isStolenWeaponsDisabled = function() return isDisabled({"autoMarkAsJunkEnabled"}) end,
+    getStolenWeaponsSetting = function() return getValue({"Stolen", "weapons"}) end,
+    setStolenWeaponsSetting = function(value) setValue(value, {"Stolen", "weapons"}) end,
+    isStolenApparelsDisabled = function() return isDisabled({"autoMarkAsJunkEnabled"}) end,
+    getStolenApparelsSetting = function() return getValue({"Stolen", "apparels"}) end,
+    setStolenApparelsSetting = function(value) setValue(value, {"Stolen", "apparels"}) end,
+    isStolenJewelriesDisabled = function() return isDisabled({"autoMarkAsJunkEnabled"}) end,
+    getStolenJewelriesSetting = function() return getValue({"Stolen", "jewelries"}) end,
+    setStolenJewelriesSetting = function(value) setValue(value, {"Stolen", "jewelries"}) end,
+    isStolenStyleMaterialsDisabled = function() return isDisabled({"autoMarkAsJunkEnabled"}) end,
+    getStolenStyleMaterialsSetting = function() return getValue({"Stolen", "styleMaterials"}) end,
+    setStolenStyleMaterialsSetting = function(value) setValue(value, {"Stolen", "styleMaterials"}) end,
+    isStolenTraitItemsDisabled = function() return isDisabled({"autoMarkAsJunkEnabled"}) end,
+    getStolenTraitItemsSetting = function() return getValue({"Stolen", "traitItems"}) end,
+    setStolenTraitItemsSetting = function(value) setValue(value, {"Stolen", "traitItems"}) end,
+    isStolenLuresDisabled = function() return isDisabled({"autoMarkAsJunkEnabled"}) end,
+    getStolenLuresSetting = function() return getValue({"Stolen", "lures"}) end,
+    setStolenLuresSetting = function(value) setValue(value, {"Stolen", "lures"}) end,
+    isStolenIngredientsDisabled = function() return isDisabled({"autoMarkAsJunkEnabled"}) end,
+    getStolenIngredientsSetting = function() return getValue({"Stolen", "ingredients"}) end,
+    setStolenIngredientsSetting = function(value) setValue(value, {"Stolen", "ingredients"}) end,
+    isStolenFoodDisabled = function() return isDisabled({"autoMarkAsJunkEnabled"}) end,
+    getStolenFoodSetting = function() return getValue({"Stolen", "food"}) end,
+    setStolenFoodSetting = function(value) setValue(value, {"Stolen", "food"}) end,
+    isStolenDrinksDisabled = function() return isDisabled({"autoMarkAsJunkEnabled"}) end,
+    getStolenDrinksSetting = function() return getValue({"Stolen", "drinks"}) end,
+    setStolenDrinksSetting = function(value) setValue(value, {"Stolen", "drinks"}) end,
+    isStolenSolventsDisabled = function() return isDisabled({"autoMarkAsJunkEnabled"}) end,
+    getStolenSolventsSetting = function() return getValue({"Stolen", "solvents"}) end,
+    setStolenSolventsSetting = function(value) setValue(value, {"Stolen", "solvents"}) end,
+    isStolenTreasuresDisabled = function() return isDisabled({"autoMarkAsJunkEnabled"}) end,
+    getStolenTreasuresSetting = function() return getValue({"Stolen", "treasures"}) end,
+    setStolenTreasuresSetting = function(value) setValue(value, {"Stolen", "treasures"}) end,
 
     -- ----------------------------------------------------------------------------------
     -- AUTO-DESTROY JUNK
     -- -----------------------------
-    isAutoDestroyWorthlessJunkDisabled = function() return isDisabled() end, -- currently always enabled
-    getAutoDestroyWorthlessJunkSetting = function() return getValue({"AutoDestroy", "destroyWorthlessJunk"}) end,
-    setAutoDestroyWorthlessJunkSetting = setPAJunkAutoDestroyWorthlessJunkSetting,
-    isDestroyMaxValueThresholdDisabled = function() return isDisabled({"AutoDestroy", "destroyWorthlessJunk"}) end,
+    isDestroyJunkMenuDisabled = function() return isDisabled({"AutoDestroy", "destroyJunk"}) end,
+    isAutoDestroyJunkDisabled = function() return isDisabled() end, -- currently always enabled
+    getAutoDestroyJunkSetting = function() return getValue({"AutoDestroy", "destroyJunk"}) end,
+    setAutoDestroyJunkSetting = setPAJunkAutoDestroyJunkSetting,
+    isDestroyMaxValueThresholdDisabled = function() return isDisabled({"AutoDestroy", "destroyJunk"}) end,
     getDestroyMaxValueThresholdSetting = function() return getValue({"AutoDestroy", "destroyMaxValueThreshold"}) end,
     setDestroyMaxValueThresholdSetting = function(value) setValue(value, {"AutoDestroy", "destroyMaxValueThreshold"}) end,
-    isDestroyMaxQualityThresholdDisabled = function() return isDisabled({"AutoDestroy", "destroyWorthlessJunk"}) end,
+    isDestroyMaxQualityThresholdDisabled = function() return isDisabled({"AutoDestroy", "destroyJunk"}) end,
     getDestroyMaxQualityThresholdSetting = function() return getValue({"AutoDestroy", "destroyMaxQualityThreshold"}) end,
     setDestroyMaxQualityThresholdSetting = function(value) setValue(value, {"AutoDestroy", "destroyMaxQualityThreshold"}) end,
+
+    isDestroyStolenJunkMenuDisabled = function() return isDisabled({"AutoDestroy", "destroyStolenJunk"}) end,
+    isAutoDestroyStolenJunkDisabled = function() return isDisabled() end, -- currently always enabled
+    getAutoDestroyStolenJunkSetting = function() return getValue({"AutoDestroy", "destroyStolenJunk"}) end,
+    setAutoDestroyStolenJunkSetting = setPAJunkAutoDestroyStolenJunkSetting,
+    isDestroyMaxStolenValueThresholdDisabled = function() return isDisabled({"AutoDestroy", "destroyStolenJunk"}) end,
+    getDestroyMaxStolenValueThresholdSetting = function() return getValue({"AutoDestroy", "destroyMaxStolenValueThreshold"}) end,
+    setDestroyMaxStolenValueThresholdSetting = function(value) setValue(value, {"AutoDestroy", "destroyMaxStolenValueThreshold"}) end,
+    isDestroyMaxStolenQualityThresholdDisabled = function() return isDisabled({"AutoDestroy", "destroyStolenJunk"}) end,
+    getDestroyMaxStolenQualityThresholdSetting = function() return getValue({"AutoDestroy", "destroyMaxStolenQualityThreshold"}) end,
+    setDestroyMaxStolenQualityThresholdSetting = function(value) setValue(value, {"AutoDestroy", "destroyMaxStolenQualityThreshold"}) end,
+
+    isDestroyExclusionDisclaimerDisabled = function() return isDisabledAll({"AutoDestroy", "destroyJunk"}, {"AutoDestroy", "destroyStolenJunk"}) end,
 
     -- ----------------------------------------------------------------------------------
     -- KEYBINDINGS

--- a/PersonalAssistant/PersonalAssistantJunk/Menu/PAJunkMenuFunctions.lua
+++ b/PersonalAssistant/PersonalAssistantJunk/Menu/PAJunkMenuFunctions.lua
@@ -369,6 +369,12 @@ local PAJunkMenuFunctions = {
     isAutoDestroyWorthlessJunkDisabled = function() return isDisabled() end, -- currently always enabled
     getAutoDestroyWorthlessJunkSetting = function() return getValue({"AutoDestroy", "destroyWorthlessJunk"}) end,
     setAutoDestroyWorthlessJunkSetting = setPAJunkAutoDestroyWorthlessJunkSetting,
+    isDestroyMaxValueThresholdDisabled = function() return isDisabled({"AutoDestroy", "destroyWorthlessJunk"}) end,
+    getDestroyMaxValueThresholdSetting = function() return getValue({"AutoDestroy", "destroyMaxValueThreshold"}) end,
+    setDestroyMaxValueThresholdSetting = function(value) setValue(value, {"AutoDestroy", "destroyMaxValueThreshold"}) end,
+    isDestroyMaxQualityThresholdDisabled = function() return isDisabled({"AutoDestroy", "destroyWorthlessJunk"}) end,
+    getDestroyMaxQualityThresholdSetting = function() return getValue({"AutoDestroy", "destroyMaxQualityThreshold"}) end,
+    setDestroyMaxQualityThresholdSetting = function(value) setValue(value, {"AutoDestroy", "destroyMaxQualityThreshold"}) end,
 
     -- ----------------------------------------------------------------------------------
     -- KEYBINDINGS

--- a/PersonalAssistant/PersonalAssistantJunk/PAJunk/PAJunkCustom.lua
+++ b/PersonalAssistant/PersonalAssistantJunk/PAJunk/PAJunkCustom.lua
@@ -12,11 +12,11 @@ local function _unmarkAllPAItemIdsFromJunk(paItemId)
     }
     local excludeJunk, excludeCharacterBound = false, false
     local paItemIdComparator = PAHF.getPAItemIdComparator(customPAItems, excludeJunk, excludeCharacterBound)
-    local backpackBagCache = SHARED_INVENTORY:GenerateFullSlotData(paItemIdComparator, BAG_BACKPACK)
-    PAJ.debugln("#backpackBagCache = "..tostring(#backpackBagCache))
+    local bagCache = SHARED_INVENTORY:GenerateFullSlotData(paItemIdComparator, PAHF.getAccessibleBags())
+    PAJ.debugln("#bagCache = "..tostring(#bagCache))
 
-    for index = #backpackBagCache, 1, -1 do
-        local itemData = backpackBagCache[index]
+    for index = #bagCache, 1, -1 do
+        local itemData = bagCache[index]
         local isJunk = IsItemJunk(itemData.bagId, itemData.slotIndex)
         if isJunk then
             SetItemIsJunk(itemData.bagId, itemData.slotIndex, false)
@@ -32,11 +32,11 @@ local function _markAllPAItemIdsAsJunk(paItemId)
     }
     local excludeJunk, excludeCharacterBound = true, false
     local paItemIdComparator = PAHF.getPAItemIdComparator(customPAItems, excludeJunk, excludeCharacterBound)
-    local backpackBagCache = SHARED_INVENTORY:GenerateFullSlotData(paItemIdComparator, BAG_BACKPACK)
-    PAJ.debugln("#backpackBagCache = "..tostring(#backpackBagCache))
+    local bagCache = SHARED_INVENTORY:GenerateFullSlotData(paItemIdComparator, PAHF.getAccessibleBags())
+    PAJ.debugln("#bagCache = "..tostring(#bagCache))
 
-    for index = #backpackBagCache, 1, -1 do
-        local itemData = backpackBagCache[index]
+    for index = #bagCache, 1, -1 do
+        local itemData = bagCache[index]
         if CanItemBeMarkedAsJunk(itemData.bagId, itemData.slotIndex) then
             SetItemIsJunk(itemData.bagId, itemData.slotIndex, true)
             PlaySound(SOUNDS.INVENTORY_ITEM_JUNKED)

--- a/PersonalAssistant/PersonalAssistantJunk/Profiles/PAJunkSavedVarsPatcher.lua
+++ b/PersonalAssistant/PersonalAssistantJunk/Profiles/PAJunkSavedVarsPatcher.lua
@@ -31,16 +31,34 @@ local function _applyPatch_2_5_11(savedVarsVersion, isPatchingNeeded)
             if istable(PASavedVars.Junk[profileNo]) then
                 -- 1) Copy profile name
                 PASavedVars.Junk[profileNo].name = PASavedVars.General[profileNo].name
-                -- 2) Remove permanent PAJunk rules for items that cannot be sold
-                local PAJCustomPAItemIds = PASavedVars.Junk[profileNo].Custom.PAItemIds
-                for _, junkConfig in pairs(PAJCustomPAItemIds) do
-                    local itemLink = junkConfig.itemLink
-                    local sellInformation = GetItemLinkSellInformation(itemLink)
-                    if sellInformation == ITEM_SELL_INFORMATION_CANNOT_SELL then
-                        -- remove from permanent junk
-                        PA.Junk.Custom.removeItemLinkFromPermanentJunk(itemLink)
-                    end
-                end
+                -- 2) Migrate 'destroyWorthlessJunk' to 'destroyJunk'
+                PASavedVars.Junk[profileNo].AutoDestroy.destroyJunk = PASavedVars.Junk[profileNo].AutoDestroy.destroyWorthlessJunk
+                PASavedVars.Junk[profileNo].AutoDestroy.destroyWorthlessJunk = nil
+                -- 3) Migrate Stolen section
+                PASavedVars.Junk[profileNo].Stolen.weapons = (PASavedVars.Junk[profileNo].Stolen.Weapons.action ~= PAC.ITEM_ACTION.NOTHING)
+                PASavedVars.Junk[profileNo].Stolen.Weapons = nil
+                PASavedVars.Junk[profileNo].Stolen.apparels = (PASavedVars.Junk[profileNo].Stolen.Armor.action ~= PAC.ITEM_ACTION.NOTHING)
+                PASavedVars.Junk[profileNo].Stolen.Armor = nil
+                PASavedVars.Junk[profileNo].Stolen.jewelries = (PASavedVars.Junk[profileNo].Stolen.Jewelry.action ~= PAC.ITEM_ACTION.NOTHING)
+                PASavedVars.Junk[profileNo].Stolen.Jewelry = nil
+                PASavedVars.Junk[profileNo].Stolen.trash = (PASavedVars.Junk[profileNo].Stolen.trashAction ~= PAC.ITEM_ACTION.NOTHING)
+                PASavedVars.Junk[profileNo].Stolen.trashAction = nil
+                PASavedVars.Junk[profileNo].Stolen.styleMaterials = (PASavedVars.Junk[profileNo].Stolen.styleMaterialAction ~= PAC.ITEM_ACTION.NOTHING)
+                PASavedVars.Junk[profileNo].Stolen.styleMaterialAction = nil
+                PASavedVars.Junk[profileNo].Stolen.traitItems = (PASavedVars.Junk[profileNo].Stolen.traitItemAction ~= PAC.ITEM_ACTION.NOTHING)
+                PASavedVars.Junk[profileNo].Stolen.traitItemAction = nil
+                PASavedVars.Junk[profileNo].Stolen.lures = (PASavedVars.Junk[profileNo].Stolen.lureAction ~= PAC.ITEM_ACTION.NOTHING)
+                PASavedVars.Junk[profileNo].Stolen.lureAction = nil
+                PASavedVars.Junk[profileNo].Stolen.ingredients = (PASavedVars.Junk[profileNo].Stolen.ingredientAction ~= PAC.ITEM_ACTION.NOTHING)
+                PASavedVars.Junk[profileNo].Stolen.ingredientAction = nil
+                PASavedVars.Junk[profileNo].Stolen.food = (PASavedVars.Junk[profileNo].Stolen.foodAction ~= PAC.ITEM_ACTION.NOTHING)
+                PASavedVars.Junk[profileNo].Stolen.foodAction = nil
+                PASavedVars.Junk[profileNo].Stolen.drinks = (PASavedVars.Junk[profileNo].Stolen.drinkAction ~= PAC.ITEM_ACTION.NOTHING)
+                PASavedVars.Junk[profileNo].Stolen.drinkAction = nil
+                PASavedVars.Junk[profileNo].Stolen.solvents = (PASavedVars.Junk[profileNo].Stolen.solventAction ~= PAC.ITEM_ACTION.NOTHING)
+                PASavedVars.Junk[profileNo].Stolen.solventAction = nil
+                PASavedVars.Junk[profileNo].Stolen.treasures = (PASavedVars.Junk[profileNo].Stolen.treasureAction ~= PAC.ITEM_ACTION.NOTHING)
+                PASavedVars.Junk[profileNo].Stolen.treasureAction = nil
             end
         end
         _updateSavedVarsVersion(savedVarsVersion)

--- a/PersonalAssistant/PersonalAssistantJunk/localization/de.lua
+++ b/PersonalAssistant/PersonalAssistantJunk/localization/de.lua
@@ -57,9 +57,14 @@ local PAJStrings = {
 
     -- Auto-Destroy --
     SI_PA_MENU_JUNK_AUTO_DESTORY_JUNK_HEADER = "Trödel direkt zerstören",
-    SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK = "Direktes Zerstören von wertlosem Trödel",
-    SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_T = "Wenn ein wertloser Gegenstand (Verkaufswert = 0g) eingesammelt wird der automatisch als Trödel markiert würde, dann wird wenn EINgeschaltet dieser Gegenstand stattdessen zerstört. Einmal zerstört kann der Gegenstand nicht zurückgeholt werden!",
+    SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK = "Direktes Zerstören von gewissem Trödel",
+    SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_T = "Wenn ein Gegenstand eingesammelt der automatisch als Trödel markiert würde, und einen Verkaufswert sowie eine Qualität hat die genau auf oder unter dem Schwellenwert liegt, dann wird wenn EINgeschaltet dieser Gegenstand stattdessen zerstört. Einmal zerstört kann der Gegenstand nicht zurückgeholt werden!",
     SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_W = "ACHTUNG: Bitte beachte dass bei Verwendung von dieser Einstellung KEINE Sicherheitsfrage kommt ob der Gegenstand wirklich zerstört werden soll.\nEr wird einfach direkt zerstört!\nUnwiderruflich!\nNutzung erfolgt auf eigenes Risiko!",
+    SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_MAX_VALUE_THRESHOLD = "WENN Verkaufswert genau auf oder unter [...] liegt",
+    SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_MAX_VALUE_THRESHOLD_T = "Nur Gegenstände deren Verkaufswert auf oder unter dem eingegeben Schwellenwert liegen werden automatisch zerstört. Wenn ein Gegenstand einmal zerstört ist, kann dies nicht mehr rückgängig gemacht werden!",
+    SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_MAX_QUALITY_THRESHOLD = "UND die Qualität genau auf oder unter [...] liegt",
+    SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_MAX_QUALITY_THRESHOLD_T = "Nur Gegenstände deren Qualität auf oder unter der ausgewählten Qualität liegen werden automatisch zerstört. Wenn ein Gegenstand einmal zerstört ist, kann dies nicht mehr rückgängig gemacht werden!",
+    SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_EXCLUSION_DISCLAIMER = "Ausnahme: Alle Arten von 'unbekannten' Gegenständen (Rezepte, Stile, Stilseiten, Eigenschaften, ...) werden nie automatisch zerstört, selbst wenn die Kriterien des Verkaufswertes und der Qualität erfüllt wären",
 
     -- Other Settings --
     SI_PA_MENU_JUNK_MAILBOX_IGNORE = "Aus Nachrichten nie als Trödel markieren",

--- a/PersonalAssistant/PersonalAssistantJunk/localization/de.lua
+++ b/PersonalAssistant/PersonalAssistantJunk/localization/de.lua
@@ -43,7 +43,11 @@ local PAJStrings = {
 
     -- Stolen Items --
     SI_PA_MENU_JUNK_AUTOMARK_STOLEN_HEADER = "Gestohlene Gegenstände",
-    SI_PA_MENU_JUNK_ACTION_STOLEN_PLACEHOLDER = "Wenn [%s] gestohlen werden",
+    SI_PA_MENU_JUNK_ACTION_STOLEN_PLACEHOLDER = "Markiere gestohlene [%s]",
+
+    -- Custom Items --
+    SI_PA_MENU_JUNK_CUSTOM_ITEMS_HEADER = "Benutzerdefinierte Gegenstände",
+    SI_PA_MENU_JUNK_CUSTOM_ITEMS_DESCRIPTION = table.concat({GetString(SI_PA_MENU_RULES_HOW_TO_ADD_PAJ), "\n\n", GetString(SI_PA_MENU_RULES_HOW_TO_FIND_MENU)}),
 
     -- Quest Items --
     SI_PA_MENU_JUNK_QUEST_ITEMS_HEADER = "Zu schützende Quest Gegenstände",
@@ -51,20 +55,26 @@ local PAJStrings = {
     SI_PA_MENU_JUNK_QUEST_THIEVES_GUILD_HEADER = "Diebesgilde",
     SI_PA_MENU_JUNK_QUEST_NEW_LIFE_FESTIVAL_HEADER = "Neujahrsfest",
 
-    -- Custom Items --
-    SI_PA_MENU_JUNK_CUSTOM_ITEMS_HEADER = "Benutzerdefinierte Gegenstände",
-    SI_PA_MENU_JUNK_CUSTOM_ITEMS_DESCRIPTION = table.concat({GetString(SI_PA_MENU_RULES_HOW_TO_ADD_PAJ), "\n\n", GetString(SI_PA_MENU_RULES_HOW_TO_FIND_MENU)}),
+    -- Auto-Sell --
+    SI_PA_MENU_JUNK_AUTO_SELL_JUNK_HEADER = "Trödel direkt verkaufen",
 
     -- Auto-Destroy --
-    SI_PA_MENU_JUNK_AUTO_DESTORY_JUNK_HEADER = "Trödel direkt zerstören",
-    SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK = "Direktes Zerstören von gewissem Trödel",
-    SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_T = "Wenn ein Gegenstand eingesammelt der automatisch als Trödel markiert würde, und einen Verkaufswert sowie eine Qualität hat die genau auf oder unter dem Schwellenwert liegt, dann wird wenn EINgeschaltet dieser Gegenstand stattdessen zerstört. Einmal zerstört kann der Gegenstand nicht zurückgeholt werden!",
+    SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_HEADER = "Trödel direkt zerstören",
+    SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK = "Direktes Zerstören von Trödel",
+    SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_T = "Wenn ein Gegenstand eingesammelt wird der automatisch als Trödel markiert würde, und einen Verkaufswert sowie eine Qualität hat die genau auf oder unter dem Schwellenwert liegt, dann wird wenn EINgeschaltet dieser Gegenstand stattdessen zerstört. Einmal zerstört kann der Gegenstand nicht zurückgeholt werden!",
     SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_W = "ACHTUNG: Bitte beachte dass bei Verwendung von dieser Einstellung KEINE Sicherheitsfrage kommt ob der Gegenstand wirklich zerstört werden soll.\nEr wird einfach direkt zerstört!\nUnwiderruflich!\nNutzung erfolgt auf eigenes Risiko!",
     SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_MAX_VALUE_THRESHOLD = "WENN Verkaufswert genau auf oder unter [...] liegt",
     SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_MAX_VALUE_THRESHOLD_T = "Nur Gegenstände deren Verkaufswert auf oder unter dem eingegeben Schwellenwert liegen werden automatisch zerstört. Wenn ein Gegenstand einmal zerstört ist, kann dies nicht mehr rückgängig gemacht werden!",
     SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_MAX_QUALITY_THRESHOLD = "UND die Qualität genau auf oder unter [...] liegt",
     SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_MAX_QUALITY_THRESHOLD_T = "Nur Gegenstände deren Qualität auf oder unter der ausgewählten Qualität liegen werden automatisch zerstört. Wenn ein Gegenstand einmal zerstört ist, kann dies nicht mehr rückgängig gemacht werden!",
     SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_EXCLUSION_DISCLAIMER = "Ausnahme: Alle Arten von 'unbekannten' Gegenständen (Rezepte, Stile, Stilseiten, Eigenschaften, ...) werden nie automatisch zerstört, selbst wenn die Kriterien des Verkaufswertes und der Qualität erfüllt wären",
+
+    SI_PA_MENU_JUNK_AUTO_DESTROY_STOLEN_JUNK = "Direktes Zerstören von gestohlenem Trödel",
+    SI_PA_MENU_JUNK_AUTO_DESTROY_STOLEN_JUNK_T = "Wenn ein Gegenstand gestohlen wird der automatisch als Trödel markiert würde, und einen Verkaufswert sowie eine Qualität hat die genau auf oder unter dem Schwellenwert liegt, dann wird wenn EINgeschaltet dieser Gegenstand stattdessen zerstört. Einmal zerstört kann der Gegenstand nicht zurückgeholt werden!",
+    SI_PA_MENU_JUNK_AUTO_DESTROY_STOLEN_JUNK_MAX_VALUE_THRESHOLD = "WENN Verkaufswert genau auf oder unter [...] liegt",
+    SI_PA_MENU_JUNK_AUTO_DESTROY_STOLEN_JUNK_MAX_VALUE_THRESHOLD_T = "Nur gestohlene Gegenstände deren Qualität auf oder unter der ausgewählten Qualität liegen werden automatisch zerstört. Wenn ein Gegenstand einmal zerstört ist, kann dies nicht mehr rückgängig gemacht werden!",
+    SI_PA_MENU_JUNK_AUTO_DESTROY_STOLEN_JUNK_MAX_QUALITY_THRESHOLD = "UND die Qualität genau auf oder unter [...] liegt",
+    SI_PA_MENU_JUNK_AUTO_DESTROY_STOLEN_JUNK_MAX_QUALITY_THRESHOLD_T = "Nur gestohlene Gegenstände deren Qualität auf oder unter der ausgewählten Qualität liegen werden automatisch zerstört. Wenn ein Gegenstand einmal zerstört ist, kann dies nicht mehr rückgängig gemacht werden!",
 
     -- Other Settings --
     SI_PA_MENU_JUNK_MAILBOX_IGNORE = "Aus Nachrichten nie als Trödel markieren",
@@ -132,9 +142,12 @@ local PAJStrings = {
 
     SI_PA_CHAT_JUNK_DESTROYED_KEYBINDING = table.concat({PAC.COLOR.ORANGE_RED:Colorize("Zerstört"), " %d x %s"}),
     SI_PA_CHAT_JUNK_DESTROYED_ALWAYS = table.concat({PAC.COLOR.ORANGE_RED:Colorize("Zerstört"), " %d x %s (", PAC.COLOR.ORANGE:Colorize("Immer"), ")"}),
-    SI_PA_CHAT_JUNK_DESTROYED_WORTHLESS = table.concat({PAC.COLOR.ORANGE_RED:Colorize("Zerstört"), " %d x %s (", PAC.COLOR.ORANGE:Colorize("Wertlos"), ")"}),
-    SI_PA_CHAT_JUNK_DESTROY_WORTHLESS_ON = table.concat({"Direktes Zerstören von wertlosem Trödel wurde ", PAC.COLOR.RED:Colorize("EIN"), "geschalten"}),
-    SI_PA_CHAT_JUNK_DESTROY_WORTHLESS_OFF = table.concat({"Direktes Zerstören von wertlosem Trödel wurde ", PAC.COLOR.GREEN:Colorize("AUS"), "geschalten"}),
+    SI_PA_CHAT_JUNK_DESTROYED_CRITERIA_MATCH = table.concat({PAC.COLOR.ORANGE_RED:Colorize("Zerstört"), " %d x %s (Verkaufswert: %s)"}),
+
+    SI_PA_CHAT_JUNK_DESTROY_ON = table.concat({"Direktes Zerstören von Trödel wurde ", PAC.COLOR.RED:Colorize("EIN"), "geschalten"}),
+    SI_PA_CHAT_JUNK_DESTROY_OFF = table.concat({"Direktes Zerstören von Trödel wurde ", PAC.COLOR.GREEN:Colorize("AUS"), "geschalten"}),
+    SI_PA_CHAT_JUNK_DESTROY_STOLEN_ON = table.concat({"Direktes Zerstören von gestohlenem Trödel wurde ", PAC.COLOR.RED:Colorize("EIN"), "geschalten"}),
+    SI_PA_CHAT_JUNK_DESTROY_STOLEN_OFF = table.concat({"Direktes Zerstören von gestohlenem Trödel wurde ", PAC.COLOR.GREEN:Colorize("AUS"), "geschalten"}),
 
     SI_PA_CHAT_JUNK_SOLD_ITEMS_INFO = "Gegenstände verkauft für %s",
     SI_PA_CHAT_JUNK_FENCE_LIMIT_HOURS = table.concat({GetString("SI_STOREFAILURE", STORE_FAILURE_AT_FENCE_LIMIT), " Bitte warte ~%d Stunden"}),

--- a/PersonalAssistant/PersonalAssistantJunk/localization/en.lua
+++ b/PersonalAssistant/PersonalAssistantJunk/localization/en.lua
@@ -43,7 +43,11 @@ local PAJStrings = {
 
     -- Stolen Items --
     SI_PA_MENU_JUNK_AUTOMARK_STOLEN_HEADER = "Stolen Items",
-    SI_PA_MENU_JUNK_ACTION_STOLEN_PLACEHOLDER = "When stealing [%s]",
+    SI_PA_MENU_JUNK_ACTION_STOLEN_PLACEHOLDER = "Auto-Mark stolen [%s]",
+
+    -- Custom Items --
+    SI_PA_MENU_JUNK_CUSTOM_ITEMS_HEADER = "Custom Items",
+    SI_PA_MENU_JUNK_CUSTOM_ITEMS_DESCRIPTION = table.concat({GetString(SI_PA_MENU_RULES_HOW_TO_ADD_PAJ), "\n\n", GetString(SI_PA_MENU_RULES_HOW_TO_FIND_MENU)}),
 
     -- Quest Items --
     SI_PA_MENU_JUNK_QUEST_ITEMS_HEADER = "Protecting Quest Items",
@@ -51,20 +55,29 @@ local PAJStrings = {
     SI_PA_MENU_JUNK_QUEST_THIEVES_GUILD_HEADER = "Thieves Guild",
     SI_PA_MENU_JUNK_QUEST_NEW_LIFE_FESTIVAL_HEADER = "New Life Festival",
 
-    -- Custom Items --
-    SI_PA_MENU_JUNK_CUSTOM_ITEMS_HEADER = "Custom Items",
-    SI_PA_MENU_JUNK_CUSTOM_ITEMS_DESCRIPTION = table.concat({GetString(SI_PA_MENU_RULES_HOW_TO_ADD_PAJ), "\n\n", GetString(SI_PA_MENU_RULES_HOW_TO_FIND_MENU)}),
+    -- Auto-Sell --
+    SI_PA_MENU_JUNK_AUTO_SELL_JUNK_HEADER = "Auto-sell junk",
 
     -- Auto-Destroy --
-    SI_PA_MENU_JUNK_AUTO_DESTORY_JUNK_HEADER = "Auto-Destroy Junk",
-    SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK = "Enable auto-destroy of certain junk items",
-    SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_T = "Wenn ein Gegenstand eingesammelt der automatisch als Trödel markiert würde, und einen Verkaufswert sowie eine Qualität hat die genau auf oder unter dem Schwellenwert liegt, dann wird wenn EINgeschaltet dieser Gegenstand stattdessen zerstört. Einmal zerstört kann der Gegenstand nicht zurückgeholt werden!",
+    SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_HEADER = "Auto-destroy junk",
+    SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK = "Enable auto-destroy of junk items",
+    SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_T = "When looting an item that would automatically be marked as junk and has a (Merchant) sell value and item quality at or below the threshold, then with this setting turned ON it will be destroyed instead. This cannot be reverted!",
     SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_W = "WARNING: Please be aware that using this setting, there is NO prompt message to double-confirm if the item really can be destroyed.\nIt is just going to be destroyed!\nForever!\nUse at your own risk!",
+
+    SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_JUNK_HEADER = "Junk",
     SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_MAX_VALUE_THRESHOLD = "IF merchant sell value is at or below",
     SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_MAX_VALUE_THRESHOLD_T = "Only auto-destroy items when their merchant sell value is at or below this threshold. Once an item is destroyed, it cannot be reverted!",
     SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_MAX_QUALITY_THRESHOLD = "AND item quality is at or below",
     SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_MAX_QUALITY_THRESHOLD_T = "Only auto-destroy items when their quality level is at or below this threshold. Once an item is destroyed, it cannot be reverted!",
     SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_EXCLUSION_DISCLAIMER = "Exception: Any kind of 'unknown' items (recipes, motifs, style pages, traits, ...) will never be auto-destroyed, even if they match the sell value and quality criteria",
+
+    SI_PA_MENU_JUNK_AUTO_DESTROY_STOLEN_JUNK_JUNK_HEADER = "Stolen junk",
+    SI_PA_MENU_JUNK_AUTO_DESTROY_STOLEN_JUNK = "Enable auto-destroy of stolen junk items",
+    SI_PA_MENU_JUNK_AUTO_DESTROY_STOLEN_JUNK_T = "When stealing an item that would automatically be marked as junk and has a (Fence) sell value and item quality at or below the threshold, then with this setting turned ON it will be destroyed instead. This cannot be reverted!",
+    SI_PA_MENU_JUNK_AUTO_DESTROY_STOLEN_JUNK_MAX_VALUE_THRESHOLD = "IF fence sell price is at or below",
+    SI_PA_MENU_JUNK_AUTO_DESTROY_STOLEN_JUNK_MAX_VALUE_THRESHOLD_T = "Only auto-destroy stolen items when their fence sell price is at or below this threshold. Once an item is destroyed, it cannot be reverted!",
+    SI_PA_MENU_JUNK_AUTO_DESTROY_STOLEN_JUNK_MAX_QUALITY_THRESHOLD = "AND stolen item quality is at or below",
+    SI_PA_MENU_JUNK_AUTO_DESTROY_STOLEN_JUNK_MAX_QUALITY_THRESHOLD_T = "Only auto-destroy stolen items when their quality level is at or below this threshold. Once an item is destroyed, it cannot be reverted!",
 
     -- Other Settings --
     SI_PA_MENU_JUNK_MAILBOX_IGNORE = "Never mark items received from Mailbox as Junk",
@@ -132,9 +145,12 @@ local PAJStrings = {
 
     SI_PA_CHAT_JUNK_DESTROYED_KEYBINDING = table.concat({PAC.COLOR.ORANGE_RED:Colorize("Destroyed"), " %d x %s"}),
     SI_PA_CHAT_JUNK_DESTROYED_ALWAYS = table.concat({PAC.COLOR.ORANGE_RED:Colorize("Destroyed"), " %d x %s (", PAC.COLOR.ORANGE:Colorize("Always"), ")"}),
-    SI_PA_CHAT_JUNK_DESTROYED_WORTHLESS = table.concat({PAC.COLOR.ORANGE_RED:Colorize("Destroyed"), " %d x %s (", PAC.COLOR.ORANGE:Colorize("Worthless"), ")"}),
-    SI_PA_CHAT_JUNK_DESTROY_WORTHLESS_ON = table.concat({"Auto-Destroy of worthless Junk items has been turned ", PAC.COLOR.RED:Colorize("ON")}),
-    SI_PA_CHAT_JUNK_DESTROY_WORTHLESS_OFF = table.concat({"Auto-Destroy of worthless Junk items has been turned ", PAC.COLOR.GREEN:Colorize("OFF")}),
+    SI_PA_CHAT_JUNK_DESTROYED_CRITERIA_MATCH = table.concat({PAC.COLOR.ORANGE_RED:Colorize("Destroyed"), " %d x %s (Sell value: %s)"}),
+
+    SI_PA_CHAT_JUNK_DESTROY_ON = table.concat({"Auto-Destroy of junk items has been turned ", PAC.COLOR.RED:Colorize("ON")}),
+    SI_PA_CHAT_JUNK_DESTROY_OFF = table.concat({"Auto-Destroy of junk items has been turned ", PAC.COLOR.GREEN:Colorize("OFF")}),
+    SI_PA_CHAT_JUNK_DESTROY_STOLEN_ON = table.concat({"Auto-Destroy of stolen junk items has been turned ", PAC.COLOR.RED:Colorize("ON")}),
+    SI_PA_CHAT_JUNK_DESTROY_STOLEN_OFF = table.concat({"Auto-Destroy of stolen junk items has been turned ", PAC.COLOR.GREEN:Colorize("OFF")}),
 
     SI_PA_CHAT_JUNK_SOLD_ITEMS_INFO = "Sold items for %s",
     SI_PA_CHAT_JUNK_FENCE_LIMIT_HOURS = table.concat({GetString("SI_STOREFAILURE", STORE_FAILURE_AT_FENCE_LIMIT), " Please wait ~%d hours"}),

--- a/PersonalAssistant/PersonalAssistantJunk/localization/en.lua
+++ b/PersonalAssistant/PersonalAssistantJunk/localization/en.lua
@@ -57,9 +57,14 @@ local PAJStrings = {
 
     -- Auto-Destroy --
     SI_PA_MENU_JUNK_AUTO_DESTORY_JUNK_HEADER = "Auto-Destroy Junk",
-    SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK = "Enable Auto-Destroy of worthles Junk items",
-    SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_T = "When looting a worthless item (sell value = 0g) that would automatically be marked as junk, with this setting turned ON it will be destroyed instead. This cannot be reverted!",
+    SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK = "Enable auto-destroy of certain junk items",
+    SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_T = "Wenn ein Gegenstand eingesammelt der automatisch als Trödel markiert würde, und einen Verkaufswert sowie eine Qualität hat die genau auf oder unter dem Schwellenwert liegt, dann wird wenn EINgeschaltet dieser Gegenstand stattdessen zerstört. Einmal zerstört kann der Gegenstand nicht zurückgeholt werden!",
     SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_W = "WARNING: Please be aware that using this setting, there is NO prompt message to double-confirm if the item really can be destroyed.\nIt is just going to be destroyed!\nForever!\nUse at your own risk!",
+    SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_MAX_VALUE_THRESHOLD = "IF merchant sell value is at or below",
+    SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_MAX_VALUE_THRESHOLD_T = "Only auto-destroy items when their merchant sell value is at or below this threshold. Once an item is destroyed, it cannot be reverted!",
+    SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_MAX_QUALITY_THRESHOLD = "AND item quality is at or below",
+    SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_MAX_QUALITY_THRESHOLD_T = "Only auto-destroy items when their quality level is at or below this threshold. Once an item is destroyed, it cannot be reverted!",
+    SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_EXCLUSION_DISCLAIMER = "Exception: Any kind of 'unknown' items (recipes, motifs, style pages, traits, ...) will never be auto-destroyed, even if they match the sell value and quality criteria",
 
     -- Other Settings --
     SI_PA_MENU_JUNK_MAILBOX_IGNORE = "Never mark items received from Mailbox as Junk",

--- a/PersonalAssistant/PersonalAssistantJunk/localization/fr.lua
+++ b/PersonalAssistant/PersonalAssistantJunk/localization/fr.lua
@@ -43,7 +43,11 @@ local PAJStrings = {
 
     -- Stolen Items --
     SI_PA_MENU_JUNK_AUTOMARK_STOLEN_HEADER = "Objets volés",
-    SI_PA_MENU_JUNK_ACTION_STOLEN_PLACEHOLDER = "Sur vol d'objets de type [%s]",
+    --SI_PA_MENU_JUNK_ACTION_STOLEN_PLACEHOLDER = "",
+
+    -- Custom Items --
+    SI_PA_MENU_JUNK_CUSTOM_ITEMS_HEADER = "Objets personnalisés",
+    SI_PA_MENU_JUNK_CUSTOM_ITEMS_DESCRIPTION = table.concat({GetString(SI_PA_MENU_RULES_HOW_TO_ADD_PAJ), "\n\n", GetString(SI_PA_MENU_RULES_HOW_TO_FIND_MENU)}),
 
     -- Quest Items --
     SI_PA_MENU_JUNK_QUEST_ITEMS_HEADER = "Protection des objets de quête",
@@ -51,12 +55,11 @@ local PAJStrings = {
     SI_PA_MENU_JUNK_QUEST_THIEVES_GUILD_HEADER = "La guilde des voleurs",
     SI_PA_MENU_JUNK_QUEST_NEW_LIFE_FESTIVAL_HEADER = "Festival de la Nouvelle vie",
 
-    -- Custom Items --
-    SI_PA_MENU_JUNK_CUSTOM_ITEMS_HEADER = "Objets personnalisés",
-    SI_PA_MENU_JUNK_CUSTOM_ITEMS_DESCRIPTION = table.concat({GetString(SI_PA_MENU_RULES_HOW_TO_ADD_PAJ), "\n\n", GetString(SI_PA_MENU_RULES_HOW_TO_FIND_MENU)}),
+    -- Auto-Sell --
+    --SI_PA_MENU_JUNK_AUTO_SELL_JUNK_HEADER = "",
 
     -- Auto-Destroy --
-    SI_PA_MENU_JUNK_AUTO_DESTORY_JUNK_HEADER = "Détruire automatiquement les rebuts",
+    SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_HEADER = "Détruire automatiquement les rebuts",
     --SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK = "",
     --SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_T = "",
     SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_W = "ATTENTION: Soyez conscient en utilisant cette option, il n'y a PAS de fenêtre de confirmation qui s'ouvrira pour permettre de confirmer que l'objet doit être vraiment détruit.\nIl sera immédiatement détruit !\nPour toujours !\nUtilisez à vos risques et périls !",
@@ -65,6 +68,13 @@ local PAJStrings = {
     --SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_MAX_QUALITY_THRESHOLD = "",
     --SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_MAX_QUALITY_THRESHOLD_T = "",
     --SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_EXCLUSION_DISCLAIMER = "",
+
+    --SI_PA_MENU_JUNK_AUTO_DESTROY_STOLEN_JUNK = "",
+    --SI_PA_MENU_JUNK_AUTO_DESTROY_STOLEN_JUNK_T = "",
+    --SI_PA_MENU_JUNK_AUTO_DESTROY_STOLEN_JUNK_MAX_VALUE_THRESHOLD = "",
+    --SI_PA_MENU_JUNK_AUTO_DESTROY_STOLEN_JUNK_MAX_VALUE_THRESHOLD_T = "!",
+    --SI_PA_MENU_JUNK_AUTO_DESTROY_STOLEN_JUNK_MAX_QUALITY_THRESHOLD = "",
+    --SI_PA_MENU_JUNK_AUTO_DESTROY_STOLEN_JUNK_MAX_QUALITY_THRESHOLD_T = "",
 
     -- Other Settings --
     SI_PA_MENU_JUNK_MAILBOX_IGNORE = "Ne pas mettre aux rebuts si reçu par courrier",
@@ -132,9 +142,12 @@ local PAJStrings = {
 
     SI_PA_CHAT_JUNK_DESTROYED_KEYBINDING = table.concat({PAC.COLOR.ORANGE_RED:Colorize("Détruit"), " %d x %s"}),
     SI_PA_CHAT_JUNK_DESTROYED_ALWAYS = table.concat({PAC.COLOR.ORANGE_RED:Colorize("Détruit"), " %d x %s (", PAC.COLOR.ORANGE:Colorize("Toujours"), ")"}),
-    SI_PA_CHAT_JUNK_DESTROYED_WORTHLESS = table.concat({PAC.COLOR.ORANGE_RED:Colorize("Détruit"), " %d x %s (", PAC.COLOR.ORANGE:Colorize("Sans valeur"), ")"}),
-    SI_PA_CHAT_JUNK_DESTROY_WORTHLESS_ON = table.concat({"La destruction automatique des rebuts sans valeur a été changée en ", PAC.COLOR.RED:Colorize("OUI")}),
-    SI_PA_CHAT_JUNK_DESTROY_WORTHLESS_OFF = table.concat({"La destruction automatique des rebuts sans valeur a été changée en ", PAC.COLOR.GREEN:Colorize("NON")}),
+    --SI_PA_CHAT_JUNK_DESTROYED_CRITERIA_MATCH = "",
+
+    SI_PA_CHAT_JUNK_DESTROY_ON = table.concat({"La destruction automatique des rebuts a été changée en ", PAC.COLOR.RED:Colorize("OUI")}),
+    SI_PA_CHAT_JUNK_DESTROY_OFF = table.concat({"La destruction automatique des rebuts a été changée en ", PAC.COLOR.GREEN:Colorize("NON")}),
+    --SI_PA_CHAT_JUNK_DESTROY_STOLEN_ON = table.concat({"", PAC.COLOR.RED:Colorize("OUI")}),
+    --SI_PA_CHAT_JUNK_DESTROY_STOLEN_OFF = table.concat({"", PAC.COLOR.GREEN:Colorize("NON")}),
 
     SI_PA_CHAT_JUNK_SOLD_ITEMS_INFO = "Objets vendus pour %s",
     SI_PA_CHAT_JUNK_FENCE_LIMIT_HOURS = table.concat({GetString("SI_STOREFAILURE", STORE_FAILURE_AT_FENCE_LIMIT), " Veuillez attendre ~%d heures"}),

--- a/PersonalAssistant/PersonalAssistantJunk/localization/fr.lua
+++ b/PersonalAssistant/PersonalAssistantJunk/localization/fr.lua
@@ -57,9 +57,14 @@ local PAJStrings = {
 
     -- Auto-Destroy --
     SI_PA_MENU_JUNK_AUTO_DESTORY_JUNK_HEADER = "Détruire automatiquement les rebuts",
-    SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK = "Détruire automatiquement les rebuts sans valeur",
-    SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_T = "Lors du butin, si un objet est mis aux rebuts et n'a aucune valeur (revente pour 0 pièce), il sera détruit si cette option est activée. Ceci ne peut être annulé !",
+    --SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK = "",
+    --SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_T = "",
     SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_W = "ATTENTION: Soyez conscient en utilisant cette option, il n'y a PAS de fenêtre de confirmation qui s'ouvrira pour permettre de confirmer que l'objet doit être vraiment détruit.\nIl sera immédiatement détruit !\nPour toujours !\nUtilisez à vos risques et périls !",
+    --SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_MAX_VALUE_THRESHOLD = "",
+    --SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_MAX_VALUE_THRESHOLD_T = "",
+    --SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_MAX_QUALITY_THRESHOLD = "",
+    --SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_MAX_QUALITY_THRESHOLD_T = "",
+    --SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_EXCLUSION_DISCLAIMER = "",
 
     -- Other Settings --
     SI_PA_MENU_JUNK_MAILBOX_IGNORE = "Ne pas mettre aux rebuts si reçu par courrier",

--- a/PersonalAssistant/PersonalAssistantJunk/localization/ru.lua
+++ b/PersonalAssistant/PersonalAssistantJunk/localization/ru.lua
@@ -45,18 +45,21 @@ local PAJStrings = {
     SI_PA_MENU_JUNK_AUTOMARK_STOLEN_HEADER = "Украденные вещи",
     SI_PA_MENU_JUNK_ACTION_STOLEN_PLACEHOLDER = "%s",
 
+    -- Custom Items --
+    SI_PA_MENU_JUNK_CUSTOM_ITEMS_HEADER = "Настраиваемые предметы",
+    SI_PA_MENU_JUNK_CUSTOM_ITEMS_DESCRIPTION = table.concat({GetString(SI_PA_MENU_RULES_HOW_TO_ADD_PAJ), "\n\n", GetString(SI_PA_MENU_RULES_HOW_TO_FIND_MENU)}),
+
     -- Quest Items --
     SI_PA_MENU_JUNK_QUEST_ITEMS_HEADER = "Защита квестовых предметов",
     SI_PA_MENU_JUNK_QUEST_CLOCKWORK_CITY_HEADER = "Заводной город",
     --SI_PA_MENU_JUNK_QUEST_THIEVES_GUILD_HEADER = "",
     SI_PA_MENU_JUNK_QUEST_NEW_LIFE_FESTIVAL_HEADER = "Фестиваль Новой Жизни",
 
-    -- Custom Items --
-    SI_PA_MENU_JUNK_CUSTOM_ITEMS_HEADER = "Настраиваемые предметы",
-    SI_PA_MENU_JUNK_CUSTOM_ITEMS_DESCRIPTION = table.concat({GetString(SI_PA_MENU_RULES_HOW_TO_ADD_PAJ), "\n\n", GetString(SI_PA_MENU_RULES_HOW_TO_FIND_MENU)}),
+    -- Auto-Sell --
+    --SI_PA_MENU_JUNK_AUTO_SELL_JUNK_HEADER = "",
 
     -- Auto-Destroy --
-    SI_PA_MENU_JUNK_AUTO_DESTORY_JUNK_HEADER = "Автоматически уничтожать мусор",
+    SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_HEADER = "Автоматически уничтожать мусор",
     --SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK = "",
     --SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_T = "",
     SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_W = "ВНИМАНИЕ: Обратите внимание, что при использовании этой настройки, никакого сообщения для подтверждения действия не будет!\nПросто будет уничтожен!\nНасовсем!\nИспользуйте на свой страх и риск!",
@@ -65,6 +68,13 @@ local PAJStrings = {
     --SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_MAX_QUALITY_THRESHOLD = "",
     --SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_MAX_QUALITY_THRESHOLD_T = "",
     --SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_EXCLUSION_DISCLAIMER = "",
+
+    --SI_PA_MENU_JUNK_AUTO_DESTROY_STOLEN_JUNK = "",
+    --SI_PA_MENU_JUNK_AUTO_DESTROY_STOLEN_JUNK_T = "",
+    --SI_PA_MENU_JUNK_AUTO_DESTROY_STOLEN_JUNK_MAX_VALUE_THRESHOLD = "",
+    --SI_PA_MENU_JUNK_AUTO_DESTROY_STOLEN_JUNK_MAX_VALUE_THRESHOLD_T = "!",
+    --SI_PA_MENU_JUNK_AUTO_DESTROY_STOLEN_JUNK_MAX_QUALITY_THRESHOLD = "",
+    --SI_PA_MENU_JUNK_AUTO_DESTROY_STOLEN_JUNK_MAX_QUALITY_THRESHOLD_T = "",
 
     -- Other Settings --
     SI_PA_MENU_JUNK_MAILBOX_IGNORE = "Никогда не помечать полученное по почте как хлам",
@@ -132,9 +142,12 @@ local PAJStrings = {
 
     SI_PA_CHAT_JUNK_DESTROYED_KEYBINDING = table.concat({PAC.COLOR.ORANGE_RED:Colorize("Уничтожен"), " %d x %s"}),
     SI_PA_CHAT_JUNK_DESTROYED_ALWAYS = table.concat({PAC.COLOR.ORANGE_RED:Colorize("Уничтожен"), " %d x %s (", PAC.COLOR.ORANGE:Colorize("Постоянная пометка"), ")"}),
-    SI_PA_CHAT_JUNK_DESTROYED_WORTHLESS = table.concat({PAC.COLOR.ORANGE_RED:Colorize("Уничтожен"), " %d x %s (", PAC.COLOR.ORANGE:Colorize("Мусор"), ")"}),
-    SI_PA_CHAT_JUNK_DESTROY_WORTHLESS_ON = table.concat({"Автоматическое уничтожение мусора было ", PAC.COLOR.RED:Colorize("ВКЛЮЧЕНО")}),
-    SI_PA_CHAT_JUNK_DESTROY_WORTHLESS_OFF = table.concat({"Автоматическое уничтожение мусора было ", PAC.COLOR.GREEN:Colorize("ВЫКЛЮЧЕНО")}),
+    --SI_PA_CHAT_JUNK_DESTROYED_CRITERIA_MATCH = "",
+
+    SI_PA_CHAT_JUNK_DESTROY_ON = table.concat({"Автоматическое уничтожение мусора было ", PAC.COLOR.RED:Colorize("ВКЛЮЧЕНО")}),
+    SI_PA_CHAT_JUNK_DESTROY_OFF = table.concat({"Автоматическое уничтожение мусора было ", PAC.COLOR.GREEN:Colorize("ВЫКЛЮЧЕНО")}),
+    --SI_PA_CHAT_JUNK_DESTROY_STOLEN_ON = table.concat({"", PAC.COLOR.RED:Colorize("ВКЛЮЧЕНО")}),
+    --SI_PA_CHAT_JUNK_DESTROY_STOLEN_OFF = table.concat({"", PAC.COLOR.GREEN:Colorize("ВЫКЛЮЧЕНО")}),
 
     SI_PA_CHAT_JUNK_SOLD_ITEMS_INFO = "Продано предметов на %s",
     SI_PA_CHAT_JUNK_FENCE_LIMIT_HOURS = table.concat({GetString("SI_STOREFAILURE", STORE_FAILURE_AT_FENCE_LIMIT), " Пожалуйста, подождите ~%d часов"}),

--- a/PersonalAssistant/PersonalAssistantJunk/localization/ru.lua
+++ b/PersonalAssistant/PersonalAssistantJunk/localization/ru.lua
@@ -57,9 +57,14 @@ local PAJStrings = {
 
     -- Auto-Destroy --
     SI_PA_MENU_JUNK_AUTO_DESTORY_JUNK_HEADER = "Автоматически уничтожать мусор",
-    SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK = "Включить уничтожение ненужных предметов",
-    SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_T = "При добыче бесполезного предмета (стоимость продажи - 0з) при включенном данном параметре - предмет будет уничтожен. Это не может быть отменено!",
+    --SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK = "",
+    --SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_T = "",
     SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_W = "ВНИМАНИЕ: Обратите внимание, что при использовании этой настройки, никакого сообщения для подтверждения действия не будет!\nПросто будет уничтожен!\nНасовсем!\nИспользуйте на свой страх и риск!",
+    --SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_MAX_VALUE_THRESHOLD = "",
+    --SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_MAX_VALUE_THRESHOLD_T = "",
+    --SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_MAX_QUALITY_THRESHOLD = "",
+    --SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_MAX_QUALITY_THRESHOLD_T = "",
+    --SI_PA_MENU_JUNK_AUTO_DESTROY_JUNK_EXCLUSION_DISCLAIMER = "",
 
     -- Other Settings --
     SI_PA_MENU_JUNK_MAILBOX_IGNORE = "Никогда не помечать полученное по почте как хлам",

--- a/PersonalAssistant/Utilities/HelperFunctions.lua
+++ b/PersonalAssistant/Utilities/HelperFunctions.lua
@@ -287,6 +287,14 @@ local function getBankBags()
     end
 end
 
+---@return string, string, string the applicable bags the player currently has access to (BAG_BACKPACK always, BAG_BANK and BAG_SUBSCRIBER_BANK only when bank open)
+local function getAccessibleBags()
+    if IsBankOpen() then
+        return BAG_BACKPACK, getBankBags()
+    end
+    return BAG_BACKPACK
+end
+
 
 -- =================================================================================================================
 -- == TEXT / NUMBER TRANSFORMATIONS == --
@@ -563,6 +571,7 @@ PA.HelperFunctions = {
     getStolenJunkComparator = getStolenJunkComparator,
     isPlayerDead = isPlayerDead,
     isPlayerDeadOrReincarnating = isPlayerDeadOrReincarnating,
+    getAccessibleBags = getAccessibleBags,
     getBankBags = getBankBags,
     getBagName = getBagName,
     getFormattedCurrency = getFormattedCurrency,

--- a/PersonalAssistant/Utilities/HelperFunctions.lua
+++ b/PersonalAssistant/Utilities/HelperFunctions.lua
@@ -507,6 +507,46 @@ local function getIconExtendedItemLink(itemLink)
     return itemLinkExt
 end
 
+--- Checks the itemLink if it is known (recipes and motifs), researched (item traits), or already added to collection (style pages and containers)
+---@param itemLink string the itemLink to be checked
+---@return string Constants.LEARNABLE.KNOWN, Constants.LEARNABLE.KNOWN or nil if there is no known/unknown status
+local function getItemLinkLearnableStatus(itemLink)
+    local itemType, specializedItemType = GetItemLinkItemType(itemLink)
+    local itemFilterType = GetItemLinkFilterTypeInfo(itemLink)
+    if itemType == ITEMTYPE_RECIPE then
+        if IsItemLinkRecipeKnown(itemLink) then return PAC.LEARNABLE.KNOWN end
+        return PAC.LEARNABLE.UNKNOWN
+    elseif itemType == ITEMTYPE_RACIAL_STYLE_MOTIF then
+        if IsItemLinkBook(itemLink) then
+            if IsItemLinkBookKnown(itemLink) then return PAC.LEARNABLE.KNOWN end
+            return PAC.LEARNABLE.UNKNOWN
+        end
+    elseif itemFilterType == ITEMFILTERTYPE_ARMOR or itemFilterType == ITEMFILTERTYPE_WEAPONS or itemFilterType == ITEMFILTERTYPE_JEWELRY then
+        local itemTraitType = GetItemLinkTraitType(itemLink)
+        -- only check for the research status if it has a traitType and if it is not Ornate or Intricate
+        if itemTraitType == ITEM_TRAIT_TYPE_NONE or
+                itemTraitType == ITEM_TRAIT_TYPE_ARMOR_ORNATE or itemTraitType == ITEM_TRAIT_TYPE_JEWELRY_ORNATE or itemTraitType == ITEM_TRAIT_TYPE_WEAPON_ORNATE or
+                itemTraitType == ITEM_TRAIT_TYPE_ARMOR_INTRICATE or itemTraitType == ITEM_TRAIT_TYPE_JEWELRY_INTRICATE or itemTraitType == ITEM_TRAIT_TYPE_WEAPON_INTRICATE then
+            return nil
+        end
+        if CanItemLinkBeTraitResearched(itemLink) then return PAC.LEARNABLE.UNKNOWN end
+        return PAC.LEARNABLE.KNOWN
+    elseif specializedItemType == SPECIALIZED_ITEMTYPE_CONTAINER_STYLE_PAGE or specializedItemType == SPECIALIZED_ITEMTYPE_CONTAINER then
+        local containerCollectibleId = GetItemLinkContainerCollectibleId(itemLink)
+        local collectibleName = GetCollectibleName(containerCollectibleId)
+        if collectibleName ~= nil and collectibleName ~= "" then
+            local isValidForPlayer = IsCollectibleValidForPlayer(containerCollectibleId)
+            if isValidForPlayer then
+                local isUnlocked = IsCollectibleUnlocked(containerCollectibleId)
+                if isUnlocked then return PAC.LEARNABLE.KNOWN end
+                return PAC.LEARNABLE.UNKNOWN
+            end
+        end
+    end
+    -- itemLink is neither known, nor unknown (not learnable or researchable)
+    return nil
+end
+
 -- Export
 PA.HelperFunctions = {
     round = round,
@@ -537,5 +577,6 @@ PA.HelperFunctions = {
     isAddonRunning = isAddonRunning,
     isItemLinkCharacterBound = isItemLinkCharacterBound,
     isItemLinkIntricateTraitType = isItemLinkIntricateTraitType,
-    getIconExtendedItemLink = getIconExtendedItemLink
+    getIconExtendedItemLink = getIconExtendedItemLink,
+    getItemLinkLearnableStatus = getItemLinkLearnableStatus
 }

--- a/PersonalAssistant/Utilities/SavedVarsPatcher.lua
+++ b/PersonalAssistant/Utilities/SavedVarsPatcher.lua
@@ -282,9 +282,7 @@ local function _applyPatch_2_4_4(savedVarsVersion, _, _, _, patchPAJ, _, _)
             if not PASavedVars.Junk[profileNo].Stolen.Treasure then PASavedVars.Junk[profileNo].Stolen.Treasure = {} end
 
             -- 1) migrate:      PAJunk.Miscellaneous.autoMarkTreasure
-            if PASavedVars.Junk[profileNo].Miscellaneous.autoMarkTreasure then
-                PASavedVars.Junk[profileNo].Stolen.Treasure.action = PAC.ITEM_ACTION.MARK_AS_JUNK
-            end
+            -- As of Version 2.5.11, this needs to be skipped because "PAC.ITEM_ACTION" was decommissioned
 
             -- 2) migrate:      PAJunk.Miscellaneous.excludeAMatterOfLeisure
             PASavedVars.Junk[profileNo].Stolen.Treasure.excludeAMatterOfLeisure = PASavedVars.Junk[profileNo].Miscellaneous.excludeAMatterOfLeisure
@@ -311,8 +309,8 @@ local function _applyPatch_2_4_6(savedVarsVersion, _, _, _, patchPAJ, _, _)
         local PASavedVars = PA.SavedVars
         for profileNo = 1, 8 do
             -- 1) migrate:      PASavedVars.Junk[profileNo].Stolen.Treasure.action
+            -- As of Version 2.5.11, this needs to be skipped because "PAC.ITEM_ACTION" was decommissioned
             PASavedVars.Junk[profileNo].Stolen.treasureAction = PASavedVars.Junk[profileNo].Stolen.Treasure.action
-            PASavedVars.Junk[profileNo].Miscellaneous.autoMarkTreasure = (PASavedVars.Junk[profileNo].Stolen.Treasure.action == PAC.ITEM_ACTION.MARK_AS_JUNK)
 
             -- 2) migrate:      PAJunk.Trash.excludeNibblesAndBits
             PASavedVars.Junk[profileNo].QuestProtection.ClockworkCity.excludeNibblesAndBits = PASavedVars.Junk[profileNo].Trash.excludeNibblesAndBits
@@ -468,8 +466,7 @@ local function _applyPatch_2_5_1(savedVarsVersion, _, _, _, patchPAJ, _, _)
         for profileNo = 1, PASavedVars.General.profileCounter do
             if istable(PASavedVars.Junk[profileNo]) then
                 PASavedVars.Junk[profileNo].ignoreCraftedItems = true
-                PASavedVars.Junk[profileNo].Stolen.trashAction = PAC.ITEM_ACTION.NOTHING
-                PASavedVars.Junk[profileNo].Stolen.solventAction = PAC.ITEM_ACTION.NOTHING
+                -- As of Version 2.5.11, this needs to be skipped because "PAC.ITEM_ACTION" was decommissioned
             end
         end
         _updateSavedVarsVersion(savedVarsVersion, nil, nil, nil, patchPAJ, nil, nil)

--- a/PersonalAssistant/Utilities/XML/DebugWindow.xml
+++ b/PersonalAssistant/Utilities/XML/DebugWindow.xml
@@ -51,7 +51,7 @@
                     <Anchor point="TOPLEFT" offsetX="10" offsetY="10" />
                 </Label>
 
-                <TextBuffer name="$(parent)Buffer" font="ZoFontChat" maxHistoryLines="500" mouseEnabled="true" linkEnabled="true">
+                <TextBuffer name="$(parent)Buffer" font="ZoFontChat" maxHistoryLines="2000" mouseEnabled="true" linkEnabled="true">
                     <DimensionConstraints minX="440" minY="120" />
                     <Anchor point="TOPLEFT" relativeTo="$(parent)Header" relativePoint="BOTTOMLEFT" offsetX="10" offsetY="10" />
                     <Anchor point="BOTTOMRIGHT" offsetX="-20" offsetY="-10" />

--- a/PersonalAssistant/vars/Globals.lua
+++ b/PersonalAssistant/vars/Globals.lua
@@ -839,7 +839,8 @@ PersonalAssistant.Constants = {
         DESTROY_ALWAYS = 9,
     },
 
-    ICON_POSITION = {
-        AUTO = -1,
-    },
+    LEARNABLE = {
+        KNOWN = 1,
+        UNKNOWN = 0,
+    }
 }


### PR DESCRIPTION
- extract getItemLinkLearnableStatus check to HelperFunctions
- increase max history lines ind debug window for 500 to 2000
- extensive PAJunk overhaul
  - re-ordered "Custom Junk" section
  - added new "Auto-sell junk" section
  - added new "auto-destroy junk" and "auto-destroy stolen junk" sections
  - changed "stolen" menu from dropdowns to simple checkboxes
  - improved quest protection display
  - completely re-done the PAJunk junking logic
  - permanent junk marking now also affects bank (when opened)

