### PR TITLE
PA: fixed activeprofile migration issues

### DIFF
--- a/PersonalAssistant/Menu/ItemContextMenu.lua
+++ b/PersonalAssistant/Menu/ItemContextMenu.lua
@@ -22,7 +22,7 @@ local function _addDynamicContextMenuEntries(itemLink, bagId, slotIndex)
     local paItemId = PAHF.getPAItemLinkIdentifier(itemLink)
 
     -- Add PABanking context menu entries
-    if PAProfileManager.PABanking.hasActiveProfile() then
+    if PAProfileManager.PABanking and PAProfileManager.PABanking.hasActiveProfile() then
         if PA.Banking and PA.Banking.SavedVars.Custom.customItemsEnabled then
             -- first make some checks whether banking rules are even allowed for this item
             if not _isBankingRuleNotAllowed(itemLink, bagId, slotIndex) then
@@ -60,7 +60,7 @@ local function _addDynamicContextMenuEntries(itemLink, bagId, slotIndex)
     end
 
     -- Add PAJunk context menu entries
-    if PAProfileManager.PAJunk.hasActiveProfile() then
+    if PAProfileManager.PAJunk and PAProfileManager.PAJunk.hasActiveProfile() then
         if PA.Junk and PA.Junk.SavedVars.Custom.customItemsEnabled then
             local PAJCustomPAItemIds = PA.Junk.SavedVars.Custom.PAItemIds
             local canBeMarkedAsJunk = CanItemBeMarkedAsJunk(bagId, slotIndex)
@@ -107,8 +107,8 @@ local function _getSlotTypeName(slotType)
 end
 
 local function initHooksOnInventoryContextMenu(LCM)
-    local PAProfileManager = PA.ProfileManager
-    if PAProfileManager.PABanking.hasActiveProfile() or PAProfileManager.PAJunk.hasActiveProfile() then
+    if (PAProfileManager.PABanking and PAProfileManager.PABanking.hasActiveProfile()) or
+            (PAProfileManager.PAJunk and PAProfileManager.PAJunk.hasActiveProfile()) then
         if not _hooksOnInventoryContextMenuInitialized and (PA.Banking or PA.Junk) then
             _hooksOnInventoryContextMenuInitialized = true
             LCM:RegisterContextMenu(function(inventorySlot, slotActions)

--- a/PersonalAssistant/PersonalAssistant.lua
+++ b/PersonalAssistant/PersonalAssistant.lua
@@ -47,26 +47,25 @@ local function _initDefaults()
         profileCounter = 0
     }
     -- LOCAL default values for PAProfile
-    -- TODO: figure out if SavedVarsPatcher works for this too
     Profile_Defaults = {
         General = {
-            activeProfile = 1,
+            activeProfile = PAC.GENERAL.NO_PROFILE_SELECTED_ID,
             debug = false,
         },
         Banking = {
-            activeProfile = 1,
+            activeProfile = PAC.GENERAL.NO_PROFILE_SELECTED_ID,
         },
         Integration = {
-            activeProfile = 1,
+            activeProfile = PAC.GENERAL.NO_PROFILE_SELECTED_ID,
         },
         Junk = {
-            activeProfile = 1,
+            activeProfile = PAC.GENERAL.NO_PROFILE_SELECTED_ID,
         },
         Loot = {
-            activeProfile = 1,
+            activeProfile = PAC.GENERAL.NO_PROFILE_SELECTED_ID,
         },
         Repair = {
-            activeProfile = 1,
+            activeProfile = PAC.GENERAL.NO_PROFILE_SELECTED_ID,
         }
     }
 end

--- a/PersonalAssistant/PersonalAssistantBanking/Profiles/PABankingSavedVarsPatcher.lua
+++ b/PersonalAssistant/PersonalAssistantBanking/Profiles/PABankingSavedVarsPatcher.lua
@@ -36,7 +36,7 @@ local function _applyPatch_2_5_11(savedVarsVersion, isPatchingNeeded)
     end
 end
 
--- local function _applyPatch_x_x_x(savedVarsVersion)
+-- local function _applyPatch_x_x_x(savedVarsVersion, isPatchingNeeded)
 
 -- ---------------------------------------------------------------------------------------------------------------------
 

--- a/PersonalAssistant/PersonalAssistantGeneral/Profiles/PAGeneralSavedVarsPatcher.lua
+++ b/PersonalAssistant/PersonalAssistantGeneral/Profiles/PAGeneralSavedVarsPatcher.lua
@@ -21,12 +21,32 @@ end
 
 -- ---------------------------------------------------------------------------------------------------------------------
 
--- local function _applyPatch_x_x_x(savedVarsVersion)
+local function _applyPatch_2_5_14(savedVarsVersion, isPatchingNeeded)
+    if isPatchingNeeded then
+        local PASavedVars = PA.SavedVars
+        local oldActiveProfile = PASavedVars.Profile.activeProfile
+        if oldActiveProfile ~= nil then
+            -- copy the previously selected profile
+            PASavedVars.Profile.General.activeProfile = oldActiveProfile
+            PASavedVars.Profile.Banking.activeProfile = oldActiveProfile
+            PASavedVars.Profile.Integration.activeProfile = oldActiveProfile
+            PASavedVars.Profile.Junk.activeProfile = oldActiveProfile
+            PASavedVars.Profile.Loot.activeProfile = oldActiveProfile
+            PASavedVars.Profile.Repair.activeProfile = oldActiveProfile
+            -- remove the old activeProfile
+            PASavedVars.Profile.activeProfile = nil
+        end
+        -- cannot do "_updateSavedVarsVersion", because this needs to run for every character!
+    end
+end
+
+-- local function _applyPatch_x_x_x(savedVarsVersion, isPatchingNeeded)
 
 -- ---------------------------------------------------------------------------------------------------------------------
 
 local function applyPatchIfNeeded()
-
+    -- Patch 2.5.14     April 24, 2021
+    _applyPatch_2_5_14(_getIsPatchNeededInfo(020514))
 end
 
 -- ---------------------------------------------------------------------------------------------------------------------

--- a/PersonalAssistant/PersonalAssistantIntegration/Profiles/PAIntegrationSavedVarsPatcher.lua
+++ b/PersonalAssistant/PersonalAssistantIntegration/Profiles/PAIntegrationSavedVarsPatcher.lua
@@ -36,7 +36,7 @@ local function _applyPatch_2_5_11(savedVarsVersion, isPatchingNeeded)
     end
 end
 
--- local function _applyPatch_x_x_x(savedVarsVersion)
+-- local function _applyPatch_x_x_x(savedVarsVersion, isPatchingNeeded)
 
 -- ---------------------------------------------------------------------------------------------------------------------
 

--- a/PersonalAssistant/PersonalAssistantJunk/Profiles/PAJunkSavedVarsPatcher.lua
+++ b/PersonalAssistant/PersonalAssistantJunk/Profiles/PAJunkSavedVarsPatcher.lua
@@ -65,7 +65,7 @@ local function _applyPatch_2_5_11(savedVarsVersion, isPatchingNeeded)
     end
 end
 
--- local function _applyPatch_x_x_x(savedVarsVersion)
+-- local function _applyPatch_x_x_x(savedVarsVersion, isPatchingNeeded)
 
 -- ---------------------------------------------------------------------------------------------------------------------
 

--- a/PersonalAssistant/PersonalAssistantLoot/PALoot/PALootItemIcons.lua
+++ b/PersonalAssistant/PersonalAssistantLoot/PALoot/PALootItemIcons.lua
@@ -287,7 +287,7 @@ local function initHooksOnBags()
             local listView = inventory.listView
             if listView and listView.dataTypes and listView.dataTypes[1] then
                 ZO_PreHook(listView.dataTypes[1], "setupCallback", function(control, slot)
-                    if not PA.Banking.isBankItemTransferBlocked then
+                    if PA.Banking and not PA.Banking.isBankItemTransferBlocked then
                         local bagId = control.dataEntry.data.bagId
                         local slotIndex = control.dataEntry.data.slotIndex
                         local itemLink = _getOrCreateDataEntryItemLink(control.dataEntry.data)

--- a/PersonalAssistant/PersonalAssistantLoot/PALoot/PALootItemIcons.lua
+++ b/PersonalAssistant/PersonalAssistantLoot/PALoot/PALootItemIcons.lua
@@ -287,7 +287,7 @@ local function initHooksOnBags()
             local listView = inventory.listView
             if listView and listView.dataTypes and listView.dataTypes[1] then
                 ZO_PreHook(listView.dataTypes[1], "setupCallback", function(control, slot)
-                    if not PA.Banking or PA.Banking.isBankItemTransferBlocked then
+                    if not PA.Banking or not PA.Banking.isBankItemTransferBlocked then
                         local bagId = control.dataEntry.data.bagId
                         local slotIndex = control.dataEntry.data.slotIndex
                         local itemLink = _getOrCreateDataEntryItemLink(control.dataEntry.data)

--- a/PersonalAssistant/PersonalAssistantLoot/PALoot/PALootItemIcons.lua
+++ b/PersonalAssistant/PersonalAssistantLoot/PALoot/PALootItemIcons.lua
@@ -287,7 +287,7 @@ local function initHooksOnBags()
             local listView = inventory.listView
             if listView and listView.dataTypes and listView.dataTypes[1] then
                 ZO_PreHook(listView.dataTypes[1], "setupCallback", function(control, slot)
-                    if PA.Banking and not PA.Banking.isBankItemTransferBlocked then
+                    if not PA.Banking or PA.Banking.isBankItemTransferBlocked then
                         local bagId = control.dataEntry.data.bagId
                         local slotIndex = control.dataEntry.data.slotIndex
                         local itemLink = _getOrCreateDataEntryItemLink(control.dataEntry.data)

--- a/PersonalAssistant/PersonalAssistantLoot/Profiles/PALootSavedVarsPatcher.lua
+++ b/PersonalAssistant/PersonalAssistantLoot/Profiles/PALootSavedVarsPatcher.lua
@@ -45,7 +45,7 @@ local function _applyPatch_2_5_11(savedVarsVersion, isPatchingNeeded)
     end
 end
 
--- local function _applyPatch_x_x_x(savedVarsVersion)
+-- local function _applyPatch_x_x_x(savedVarsVersion, isPatchingNeeded)
 
 -- ---------------------------------------------------------------------------------------------------------------------
 

--- a/PersonalAssistant/PersonalAssistantRepair/Profiles/PARepairSavedVarsPatcher.lua
+++ b/PersonalAssistant/PersonalAssistantRepair/Profiles/PARepairSavedVarsPatcher.lua
@@ -36,7 +36,7 @@ local function _applyPatch_2_5_11(savedVarsVersion, isPatchingNeeded)
     end
 end
 
--- local function _applyPatch_x_x_x(savedVarsVersion)
+-- local function _applyPatch_x_x_x(savedVarsVersion, isPatchingNeeded)
 
 -- ---------------------------------------------------------------------------------------------------------------------
 

--- a/PersonalAssistant/Utilities/EventManager.lua
+++ b/PersonalAssistant/Utilities/EventManager.lua
@@ -184,7 +184,7 @@ end
 -- ---------------------------------------------------------------------------------------------------------------------
 
 local function _hasAnyPAJunkIntegrationsTurnedOn()
-    if PAPM.PAIntegration.hasActiveProfile() then
+    if PAPM.PAIntegration and PAPM.PAIntegration.hasActiveProfile() then
         local PAI = PA.Integration
         if PAI and FCOIS then
             local PAIFCOISSavedVars = PAI.SavedVars.FCOItemSaver

--- a/PersonalAssistant/Utilities/XML/DebugWindow.lua
+++ b/PersonalAssistant/Utilities/XML/DebugWindow.lua
@@ -53,11 +53,21 @@ local function showStaticDebugInformationWindow()
 
     -- Active profile
     debugEditControl:InsertLine("PA.General.activeProfile="..tostring(PA.ProfileManager.PAGeneral.hasActiveProfile()).." ("..tostring(PA.ProfileManager.PAGeneral.getActiveProfile())..")")
-    debugEditControl:InsertLine("PA.Banking.activeProfile="..tostring(PA.ProfileManager.PABanking.hasActiveProfile()).." ("..tostring(PA.ProfileManager.PABanking.getActiveProfile())..")")
-    debugEditControl:InsertLine("PA.Integration.activeProfile="..tostring(PA.ProfileManager.PAIntegration.hasActiveProfile()).." ("..tostring(PA.ProfileManager.PAIntegration.getActiveProfile())..")")
-    debugEditControl:InsertLine("PA.Junk.activeProfile="..tostring(PA.ProfileManager.PAJunk.hasActiveProfile()).." ("..tostring(PA.ProfileManager.PAJunk.getActiveProfile())..")")
-    debugEditControl:InsertLine("PA.Loot.activeProfile="..tostring(PA.ProfileManager.PALoot.hasActiveProfile()).." ("..tostring(PA.ProfileManager.PALoot.getActiveProfile())..")")
-    debugEditControl:InsertLine("PA.Repair.activeProfile="..tostring(PA.ProfileManager.PARepair.hasActiveProfile()).." ("..tostring(PA.ProfileManager.PARepair.getActiveProfile())..")")
+    if PA.ProfileManager.PABanking then
+        debugEditControl:InsertLine("PA.Banking.activeProfile="..tostring(PA.ProfileManager.PABanking.hasActiveProfile()).." ("..tostring(PA.ProfileManager.PABanking.getActiveProfile())..")")
+    end
+    if PA.ProfileManager.PAIntegration then
+        debugEditControl:InsertLine("PA.Integration.activeProfile="..tostring(PA.ProfileManager.PAIntegration.hasActiveProfile()).." ("..tostring(PA.ProfileManager.PAIntegration.getActiveProfile())..")")
+    end
+    if PA.ProfileManager.PAJun then
+        debugEditControl:InsertLine("PA.Junk.activeProfile="..tostring(PA.ProfileManager.PAJunk.hasActiveProfile()).." ("..tostring(PA.ProfileManager.PAJunk.getActiveProfile())..")")
+    end
+    if PA.ProfileManager.PALoot then
+        debugEditControl:InsertLine("PA.Loot.activeProfile="..tostring(PA.ProfileManager.PALoot.hasActiveProfile()).." ("..tostring(PA.ProfileManager.PALoot.getActiveProfile())..")")
+    end
+    if PA.ProfileManager.PARepair then
+        debugEditControl:InsertLine("PA.Repair.activeProfile="..tostring(PA.ProfileManager.PARepair.hasActiveProfile()).." ("..tostring(PA.ProfileManager.PARepair.getActiveProfile())..")")
+    end
 
     -- Enabled addons
     debugEditControl:InsertLine("PA.General="..tostring(PA.General ~= nil))

--- a/PersonalAssistant/vars/Globals.lua
+++ b/PersonalAssistant/vars/Globals.lua
@@ -51,7 +51,7 @@ PersonalAssistant.Constants = {
                 LOOT = 2,
                 REPAIR = 1,
             },
-            MINOR = 020513, -- update this every release!
+            MINOR = 020514, -- update this every release!
         },
     },
 


### PR DESCRIPTION
- fixed an issue with the migration of the activeProfile
- changed default profile to be "none-selected" in case of new characters
- fixed an issue with ProfileManager when a module is not enabled
- fixed an issue where item icons where not set without PABanking running 