### PR TITLE
PAB: skip items with custom rule

### DIFF
--- a/PersonalAssistant/PersonalAssistantBanking/PABanking/PABankingAdvanced.lua
+++ b/PersonalAssistant/PersonalAssistantBanking/PABanking/PABankingAdvanced.lua
@@ -133,8 +133,8 @@ local function depositOrWithdrawAdvancedItems()
         end
 
         local excludeJunk = PAB.SavedVars.excludeJunk
-        local depositComparator = PAHF.getCombinedItemTypeSpecializedComparator(combinedDepositLists, excludeJunk)
-        local withdrawComparator = PAHF.getCombinedItemTypeSpecializedComparator(combinedWithdrawLists, excludeJunk)
+        local depositComparator = PAHF.getCombinedItemTypeSpecializedComparator(combinedDepositLists, excludeJunk, true)
+        local withdrawComparator = PAHF.getCombinedItemTypeSpecializedComparator(combinedWithdrawLists, excludeJunk, true)
 
         local toDepositBagCache = SHARED_INVENTORY:GenerateFullSlotData(depositComparator, BAG_BACKPACK)
         local toFillUpDepositBagCache = SHARED_INVENTORY:GenerateFullSlotData(depositComparator, PAHF.getBankBags())

--- a/PersonalAssistant/PersonalAssistantBanking/PABanking/PABankingCustom.lua
+++ b/PersonalAssistant/PersonalAssistantBanking/PABanking/PABankingCustom.lua
@@ -7,6 +7,18 @@ local PAEM = PA.EventManager
 
 -- ---------------------------------------------------------------------------------------------------------------------
 
+local function hasItemActiveCustomRule(bagId, slotIndex)
+    local PABCUstomPAItemIds = PAB.SavedVars.Custom.PAItemIds
+    local paItemId = PAHF.getPAItemIdentifier(bagId, slotIndex)
+    if PAHF.isKeyInTable(PABCUstomPAItemIds, paItemId) then
+        if PABCUstomPAItemIds[paItemId].ruleEnabled then
+            PAB.debugln("%s has an active Custom Rule", GetItemName(bagId, slotIndex))
+            return true
+        end
+    end
+    return false
+end
+
 local function depositOrWithdrawCustomItems()
 
     PAB.debugln("==============================================================")
@@ -56,4 +68,5 @@ end
 -- ---------------------------------------------------------------------------------------------------------------------
 -- Export
 PA.Banking = PA.Banking or {}
+PA.Banking.hasItemActiveCustomRule = hasItemActiveCustomRule
 PA.Banking.depositOrWithdrawCustomItems = depositOrWithdrawCustomItems

--- a/PersonalAssistant/Utilities/HelperFunctions.lua
+++ b/PersonalAssistant/Utilities/HelperFunctions.lua
@@ -43,12 +43,7 @@ end
 ---@param key string|number the key that might in the table
 ---@return boolean whether the key exists in the table
 local function isKeyInTable(table, key)
-    for k in pairs(table) do
-        if k == key then
-            return true
-        end
-    end
-    return false
+    return table[key] ~= nil
 end
 
 

--- a/PersonalAssistant/Utilities/HelperFunctions.lua
+++ b/PersonalAssistant/Utilities/HelperFunctions.lua
@@ -123,8 +123,9 @@ end
 
 ---@param combinedLists table a complex list of holidayWrits, itemTypes, surveyMaps, itemTraitTypes, masterWritCraftingTypes, specializedItemTypes, learnableKnowItemTypes and learnableUnknownItemTypes
 ---@param excludeJunk boolean whether junk items should be excluded
+---@param skipItemsWithCustomRule boolean whether items for which a custom rule exists should be skipped
 ---@return fun(itemData: table) a comparator function that only returns item that match the complex list and pass the junk-test
-local function getCombinedItemTypeSpecializedComparator(combinedLists, excludeJunk)
+local function getCombinedItemTypeSpecializedComparator(combinedLists, excludeJunk, skipItemsWithCustomRule)
     local function _isItemOfItemTypeAndKnowledge(itemType, itemLink, expectedItemType, expectedIsKnown)
         if itemType == expectedItemType then
             if itemType == ITEMTYPE_RACIAL_STYLE_MOTIF then
@@ -163,6 +164,7 @@ local function getCombinedItemTypeSpecializedComparator(combinedLists, excludeJu
         if IsItemJunk(itemData.bagId, itemData.slotIndex) and excludeJunk then return false end
         if IsItemStolen(itemData.bagId, itemData.slotIndex) then return false end
         if _isItemCharacterBound(itemData) then return false end
+        if skipItemsWithCustomRule and PA.Banking.hasItemActiveCustomRule(itemData.bagId, itemData.slotIndex) then return false end
         local itemId = GetItemId(itemData.bagId, itemData.slotIndex)
         local itemType, specializedItemType = GetItemType(itemData.bagId, itemData.slotIndex)
         if specializedItemType == SPECIALIZED_ITEMTYPE_HOLIDAY_WRIT then


### PR DESCRIPTION
Skip items during standard PABanking item transfer if there is an active custom rule for the same item