### PR TITLE
PAJ: fixed an issue regarding companion items and marking them as junk

### DIFF
--- a/PersonalAssistant/Menu/ItemContextMenu.lua
+++ b/PersonalAssistant/Menu/ItemContextMenu.lua
@@ -62,26 +62,28 @@ local function _addDynamicContextMenuEntries(itemLink, bagId, slotIndex)
     -- Add PAJunk context menu entries
     if PAProfileManager.PAJunk and PAProfileManager.PAJunk.hasActiveProfile() then
         if PA.Junk and PA.Junk.SavedVars.Custom.customItemsEnabled then
-            local PAJCustomPAItemIds = PA.Junk.SavedVars.Custom.PAItemIds
-            local canBeMarkedAsJunk = CanItemBeMarkedAsJunk(bagId, slotIndex)
-            local isRuleExisting = PAHF.isKeyInTable(PAJCustomPAItemIds, paItemId)
-            local entries = {
-                {
-                    label = GetString(SI_PA_SUBMENU_PAJ_MARK_PERM_JUNK),
-                    callback = function()
-                        PA.Junk.Custom.addItemLinkToPermanentJunk(itemLink)
-                    end,
-                    disabled = function() return not canBeMarkedAsJunk or isRuleExisting end,
-                },
-                {
-                    label = GetString(SI_PA_SUBMENU_PAJ_UNMARK_PERM_JUNK),
-                    callback = function()
-                        PA.Junk.Custom.removeItemLinkFromPermanentJunk(itemLink)
-                    end,
-                    disabled = function() return not isRuleExisting end,
+            local canBeMarkedAsJunk = PAHF.CanItemBeMarkedAsJunkExt(bagId, slotIndex)
+            if canBeMarkedAsJunk then
+                local PAJCustomPAItemIds = PA.Junk.SavedVars.Custom.PAItemIds
+                local isRuleExisting = PAHF.isKeyInTable(PAJCustomPAItemIds, paItemId)
+                local entries = {
+                    {
+                        label = GetString(SI_PA_SUBMENU_PAJ_MARK_PERM_JUNK),
+                        callback = function()
+                            PA.Junk.Custom.addItemLinkToPermanentJunk(itemLink)
+                        end,
+                        disabled = function() return isRuleExisting end,
+                    },
+                    {
+                        label = GetString(SI_PA_SUBMENU_PAJ_UNMARK_PERM_JUNK),
+                        callback = function()
+                            PA.Junk.Custom.removeItemLinkFromPermanentJunk(itemLink)
+                        end,
+                        disabled = function() return not isRuleExisting end,
+                    }
                 }
-            }
-            AddCustomSubMenuItem(GetString(SI_PA_SUBMENU_PAJ), entries)
+                AddCustomSubMenuItem(GetString(SI_PA_SUBMENU_PAJ), entries)
+            end
         end
     end
 end

--- a/PersonalAssistant/PersonalAssistantJunk/PAJunk/PAJunk.lua
+++ b/PersonalAssistant/PersonalAssistantJunk/PAJunk/PAJunk.lua
@@ -416,7 +416,7 @@ end
 local function _markItemAsJunkIfPossible(bagId, slotIndex, itemLink, markAsJunkSuccessMessageKey)
     PAJ.debugln("_markItemAsJunkIfPossible: %s", itemLink)
     -- Check if ESO allows the item to be marked as junk
-    if CanItemBeMarkedAsJunk(bagId, slotIndex) then
+    if PAHF.CanItemBeMarkedAsJunkExt(bagId, slotIndex) then
         -- then check if the item unique; if yes then don't mark it as junk
         local isUnique = IsItemLinkUnique(itemLink)
         if not isUnique then

--- a/PersonalAssistant/PersonalAssistantJunk/PAJunk/PAJunkCustom.lua
+++ b/PersonalAssistant/PersonalAssistantJunk/PAJunk/PAJunkCustom.lua
@@ -37,7 +37,7 @@ local function _markAllPAItemIdsAsJunk(paItemId)
 
     for index = #bagCache, 1, -1 do
         local itemData = bagCache[index]
-        if CanItemBeMarkedAsJunk(itemData.bagId, itemData.slotIndex) then
+        if PAHF.CanItemBeMarkedAsJunkExt(itemData.bagId, itemData.slotIndex) then
             SetItemIsJunk(itemData.bagId, itemData.slotIndex, true)
             PlaySound(SOUNDS.INVENTORY_ITEM_JUNKED)
         end

--- a/PersonalAssistant/Utilities/HelperFunctions.lua
+++ b/PersonalAssistant/Utilities/HelperFunctions.lua
@@ -109,6 +109,14 @@ local function isItemLinkForCompanion(itemLink)
     return actorCategory == GAMEPLAY_ACTOR_CATEGORY_COMPANION -- ~= GAMEPLAY_ACTOR_CATEGORY_PLAYER
 end
 
+--- workaround function since ZOS' "CanItemBeMarkedAsJunk" function does not check for companion items
+---@param bagId number representation of the bag
+---@param slotIndex number representation of the slot
+---@return boolean whether the item can be marked as junk or not
+local function CanItemBeMarkedAsJunkExt(bagId, slotIndex)
+    return CanItemBeMarkedAsJunk(bagId, slotIndex) and not isItemForCompanion(bagId, slotIndex)
+end
+
 -- =================================================================================================================
 -- == COMPARATORS == --
 -- -----------------------------------------------------------------------------------------------------------------
@@ -576,6 +584,7 @@ PA.HelperFunctions = {
     getPAItemIdentifierFromItemData = getPAItemIdentifierFromItemData,
     isItemForCompanion = isItemForCompanion,
     isItemLinkForCompanion = isItemLinkForCompanion,
+    CanItemBeMarkedAsJunkExt = CanItemBeMarkedAsJunkExt,
     isItemCharacterBound = isItemCharacterBound,
     getCombinedItemTypeSpecializedComparator = getCombinedItemTypeSpecializedComparator,
     getItemTypeComparator = getItemTypeComparator,


### PR DESCRIPTION
resolves #385 

custom implementation was required, because ZOS' ```CanItemBeMarkedAsJunk()``` wrongly returns 'true' for companion items