### PR TITLE
PAR: temporarily disable crown repair kits (default to gold-bought ones)

### DIFF
--- a/PersonalAssistant/PersonalAssistantRepair/Menu/PARepairMenu.lua
+++ b/PersonalAssistant/PersonalAssistantRepair/Menu/PARepairMenu.lua
@@ -279,6 +279,8 @@ local function _createPARRepairKitSubmenuTable()
         type = "dropdown",
         name = GetString(SI_PA_MENU_REPAIR_REPAIRKIT_DEFAULT_KIT),
         tooltip = GetString(SI_PA_MENU_REPAIR_REPAIRKIT_DEFAULT_KIT_T),
+        -- FIXME: remove warning again once proper solution is found
+        warning = "Crown Repair Kits are temporarily disabled until a proper solution is found for PARepair to correctly repair all items with them.",
         choices = PARMenuChoices.defaultRepairKit,
         choicesValues = PARMenuChoicesValues.defaultRepairKit,
         getFunc = PARMenuFunctions.getRepairDefaultRepairKitSetting,

--- a/PersonalAssistant/PersonalAssistantRepair/Menu/PARepairMenuFunctions.lua
+++ b/PersonalAssistant/PersonalAssistantRepair/Menu/PARepairMenuFunctions.lua
@@ -59,8 +59,10 @@ local PARepairMenuFunctions = {
     getRepairWithRepairKitSetting = function() return getValue({"RepairEquipped", "repairWithRepairKit"}) end,
     setRepairWithRepairKitSetting = function(value) setValueAndRefreshEvents(value, {"RepairEquipped", "repairWithRepairKit"}) end,
 
-    isRepairDefaultRepairKitDisabled = function() return isDisabled({"autoRepairEnabled"}, {"RepairEquipped", "repairWithRepairKit"}) end,
-    getRepairDefaultRepairKitSetting = function() return getValue({"RepairEquipped", "defaultRepairKit"}) end,
+    isRepairDefaultRepairKitDisabled = function() return true end, -- FIXME: always disabled until a solution is found to correctly use Crown Repair Kits
+    --isRepairDefaultRepairKitDisabled = function() return isDisabled({"autoRepairEnabled"}, {"RepairEquipped", "repairWithRepairKit"}) end,
+    getRepairDefaultRepairKitSetting = function() return DEFAULT_SOUL_GEM_CHOICE_GOLD end,  -- FIXME: always return DEFAULT_SOUL_GEM_CHOICE_GOLD until a solution is found to correctly use Crown Repair Kits
+    --getRepairDefaultRepairKitSetting = function() return getValue({"RepairEquipped", "defaultRepairKit"}) end,
     setRepairDefaultRepairKitSetting = function(value) setValueAndRefreshEvents(value, {"RepairEquipped", "defaultRepairKit"}) end,
 
     isRepairWithRepairKitDurabilityThresholdDisabled = function() return isDisabled({"autoRepairEnabled"}, {"RepairEquipped", "repairWithRepairKit"}) end,

--- a/PersonalAssistant/PersonalAssistantRepair/PARepair/PARepairKit.lua
+++ b/PersonalAssistant/PersonalAssistantRepair/PARepair/PARepairKit.lua
@@ -10,7 +10,8 @@ local _lastNoRepairKitWarningGameTime = 0
 
 local _repairKitItemIds = {
     [44879] = true,  -- Grand Repair Kit    Tier=6
-    [61079] = true,  -- Crown Repair Kit    Tier=7
+    -- FIXME: always disabled until a solution is found to correctly use Crown Repair Kits
+    --[61079] = true,  -- Crown Repair Kit    Tier=7
 }
 
 -- --------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Issue reported on gitter to DanBatson:
`ZOSDanBatson I just noticed that when RepairItemWithRepairKit() is called with the bagId/slotIndex of a Crown Repair Kit, it also consumes the kit, but only repairs the one single item; not all damaged ones. Is this intended? And if yes, would I have to call the protected UseItem() function instead to repair all items? (i.e. crown repair kits cannot be automatically used during combat)`